### PR TITLE
Accept IDs in arguments to push, create-release, deploy-release, promote-release

### DIFF
--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -127,7 +127,7 @@ namespace Octo.Tests.Commands
             var argsWithSpaceName = CommandLineArgs.Concat(new[] { "--space=nonExistent" });
 
             Func<Task> action = async () => await apiCommand.Execute(argsWithSpaceName.ToArray()).ConfigureAwait(false);
-            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
+            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name or id 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
         }
     }
 }

--- a/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
@@ -57,17 +57,20 @@ namespace Octo.Tests.Commands
             
             Repository.Machines.FindByNames(Arg.Any<IEnumerable<string>>(), Arg.Any<string>(), Arg.Any<object>())
                 .Returns(new List<MachineResource>());
+
+            var environmentResource = new EnvironmentResource() {Name = ValidEnvironment};
             Repository.Environments.FindByNames(
                     Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 == ValidEnvironment)),
                     Arg.Any<string>(),
                     Arg.Any<object>())
-                .Returns(new List<EnvironmentResource>() {new EnvironmentResource() {Name = ValidEnvironment}});
+                .Returns(new List<EnvironmentResource>() {environmentResource});
             Repository.Environments.FindByNames(
                     Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 != ValidEnvironment)), 
                     Arg.Any<string>(), 
                     Arg.Any<object>())
                 .Returns(new List<EnvironmentResource>());
-            
+            Repository.Environments.FindByName(ValidEnvironment).Returns(environmentResource);
+
             ClientFactory = Substitute.For<IOctopusClientFactory>();
 
             RepositoryFactory = Substitute.For<IOctopusAsyncRepositoryFactory>();

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Cli.Commands.Releases;
@@ -45,10 +49,10 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--releaseNumber=1.0.0");
             CommandLineArgs.Add("--tenantTag=bad");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"\btag\b", RegexOptions.IgnoreCase));
         }
         
         [Test]
@@ -60,12 +64,12 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--tenant=bad");
+            CommandLineArgs.Add("--tenant=badTenant");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"tenant.*badTenant", RegexOptions.IgnoreCase));
         }
         
         [Test]
@@ -77,12 +81,12 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--specificmachines=bad");
+            CommandLineArgs.Add("--specificmachines=badMach");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"machine.*badMach", RegexOptions.IgnoreCase));
         }
         
                 
@@ -95,11 +99,11 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--deployto=bad");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+            CommandLineArgs.Add("--deployto=badEnv");
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>().Where(ex =>
+                Regex.IsMatch(ex.Message, @"environment.*badEnv", RegexOptions.IgnoreCase));
         }
         
     }

--- a/source/Octo.Tests/Commands/DeployReleaseCommandTestFixture.cs
+++ b/source/Octo.Tests/Commands/DeployReleaseCommandTestFixture.cs
@@ -121,8 +121,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--progress");
             CommandLineArgs.Add("--cancelontimeout");
 
-            var environments = new List<EnvironmentResource> {new EnvironmentResource { Name = targetEnvironment}};
-            Repository.Environments.FindByNames(Arg.Any<IEnumerable<string>>()).Returns(environments);
+            var environment = new EnvironmentResource {Name = targetEnvironment};
+            Repository.Environments.FindByName(Arg.Any<string>()).Returns(environment);
             Repository.Releases.GetTemplate(Arg.Any<ReleaseResource>()).Returns(new DeploymentTemplateResource
                 {PromoteTo = new List<DeploymentPromotionTarget>() {new DeploymentPromotionTarget{Name = targetEnvironment}}});
             Repository.Releases.GetPreview(Arg.Any<DeploymentPromotionTarget>())

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -69,11 +69,9 @@ namespace Octopus.Cli.Commands
             options.Add("proxy=", $"[Optional] The URI of the proxy to use, eg http://example.com:8080.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
-            options.Add("space=", $"[Optional] The name of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);
+            options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);
             options.AddLogLevelOptions();
         }
-
-        protected ILogger Log { get; }
 
         protected string ServerBaseUrl => string.IsNullOrWhiteSpace(serverBaseUrl)
                     ? System.Environment.GetEnvironmentVariable(ServerUrlEnvVar)
@@ -150,12 +148,7 @@ namespace Octopus.Cli.Commands
                     throw new CommandException($"The server {endpoint.OctopusServer} has no spaces. Try invoking the Octo tool without specifying the space name as an argument");
                 }
 
-                commandOutputProvider.Debug("Finding space: {Space:l}", spaceName);
-                var space = await client.ForSystem().Spaces.FindByName(spaceName).ConfigureAwait(false);
-                if (space == null)
-                {
-                    throw new CommandException($"Cannot find the space with name '{spaceName}'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
-                }
+                var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceName).ConfigureAwait(false);
 
                 Repository = repositoryFactory.CreateRepository(client, RepositoryScope.ForSpace(space));
                 commandOutputProvider.Debug("Space name specified, process is now running in the context of space: {space:l}", spaceName);

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("deployto=", "Environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelName = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -21,7 +21,7 @@ namespace Octopus.Cli.Commands.Deployment
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Deployment");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("deployto=", "Environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use when getting the release to deploy", v => ChannelName = v);
@@ -44,7 +44,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         public async Task Request()
         {
-            project = await RepositoryCommonQueries.GetProjectByName(ProjectName).ConfigureAwait(false);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
             channel = await GetChannel(project).ConfigureAwait(false);
             releaseToPromote = await RepositoryCommonQueries.GetReleaseByVersion(VersionNumber, project, channel).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -141,18 +141,8 @@ namespace Octopus.Cli.Commands.Deployment
             } 
             
             // Make sure environment is valid
-            var environments = await Repository.Environments.FindByNames(DeployToEnvironmentNames).ConfigureAwait(false);
-            var missingEnvironment = DeployToEnvironmentNames
-                .Where(env => environments.All(env2 => !env2.Name.Equals(env, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
-            if (missingEnvironment.Count != 0)
-            {
-                throw new CommandException(
-                    $"The environment{(missingEnvironment.Count == 1 ? "" : "s")} {string.Join(", ", missingEnvironment)} " +
-                    $"do{(missingEnvironment.Count == 1 ? "es" : "")} not exist or {(missingEnvironment.Count == 1 ? "is" : "are")} misspelled");
-            }
-            
-            
+            await Repository.Environments.FindByNamesOrIdsOrFail(DeployToEnvironmentNames).ConfigureAwait(false);
+
             // Make sure the machines are valid
             await GetSpecificMachines();
 

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -80,7 +80,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name using the parameter: --project=XYZ");
+            if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (IsTenantedDeployment && DeployToEnvironmentNames.Count > 1) throw new CommandException("Please specify only one environment at a time when deploying to tenants.");
             if (Tenants.Contains("*") && (Tenants.Count > 1 || TenantTags.Count > 0)) throw new CommandException("When deploying to all tenants using --tenant=* wildcard no other tenant filters can be provided");
             if (IsTenantedDeployment && !await Repository.SupportsTenants().ConfigureAwait(false))

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -45,7 +45,7 @@ namespace Octopus.Cli.Commands.Releases
             options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
         }
 
         public string ChannelName { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Commands.Releases
             this.releasePlanBuilder = releasePlanBuilder;
 
             var options = Options.For("Release creation");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
             options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelName = v);
@@ -70,11 +70,7 @@ namespace Octopus.Cli.Commands.Releases
             var serverSupportsChannels = await ServerSupportsChannels();
             commandOutputProvider.Debug(serverSupportsChannels ? "This Octopus Server supports channels" : "This Octopus Server does not support channels");
 
-            commandOutputProvider.Debug("Finding project: {Project:l}", ProjectName);
-            
-            project = await Repository.Projects.FindByName(ProjectName).ConfigureAwait(false);
-            if (project == null)
-                throw new CouldNotFindException("a project named", ProjectName);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
 
             plan = await BuildReleasePlan(project).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -21,7 +21,7 @@ namespace Octopus.Cli.Commands.Releases
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Release Promotion");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("from=", "Name of the environment to get the current deployment from, e.g., Staging", v => FromEnvironmentName = v);
             options.Add("to=|deployto=", "Environment to deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
@@ -40,11 +40,7 @@ namespace Octopus.Cli.Commands.Releases
 
         public async Task Request()
         {
-            commandOutputProvider.Debug("Finding project: {Project:l}", ProjectName);
-            
-            project = await Repository.Projects.FindByName(ProjectName).ConfigureAwait(false);
-            if (project == null)
-                throw new CouldNotFindException("a project named", ProjectName);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
 
             commandOutputProvider.Debug("Finding environment: {Environment:l}", FromEnvironmentName);
             

--- a/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
+++ b/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
@@ -3,7 +3,7 @@
     public class CouldNotFindException : CommandException
     {
         public CouldNotFindException(string what)
-            : base("Could not find " + what  + "; either it does not exist or you lack permissions to view it.")
+            : base("Could not find " + what + "; either it does not exist or you lack permissions to view it.")
         {
         }
 
@@ -12,5 +12,10 @@
         {
         }
 
+        public CouldNotFindException(string typeDescription, string nameOrId, string inDescription) : base(
+            $"Cannot find the {typeDescription} with name or id '{nameOrId}'{inDescription}. "
+            + $"Please check the spelling and that the account has sufficient access to that {typeDescription}. Please use Configuration > Test Permissions to confirm.")
+        {
+        }
     }
 }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Sprache" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.3.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Octopus.Cli/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Cli/Util/RepositoryExtensions.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Octopus.Cli.Infrastructure;
+using Octopus.Client.Exceptions;
+using Octopus.Client.Logging;
+using Octopus.Client.Model;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Cli.Util
+{
+    public static class RepositoryExtensions
+    {
+        private static readonly ILog Logger = LogProvider.GetLogger(typeof(RepositoryExtensions));
+
+        private static async Task<TResource> FindByNameOrIdOrFail<T, TResource>(this T repository,
+            Func<string, Task<TResource>> findByNameFunc, string fixedIdPrefix, string typeDescription, string nameOrId,
+            string inDescription = "", bool skipLog = false)
+            where T : IGet<TResource> where TResource : Resource
+        {
+            if (!skipLog)
+            {
+                Logger.Debug($"Finding {typeDescription}: {nameOrId}");
+            }
+
+            TResource resourceById;
+            if (!Regex.IsMatch(nameOrId, $@"^{Regex.Escape(fixedIdPrefix)}-\d+$",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase))
+            {
+                resourceById = null;
+            }
+            else
+            {
+                try
+                {
+                    resourceById = await repository.Get(nameOrId)
+                        .ConfigureAwait(false);
+                }
+                catch (OctopusResourceNotFoundException)
+                {
+                    resourceById = null;
+                }
+            }
+
+            var resourceByName = await findByNameFunc(nameOrId)
+                .ConfigureAwait(false);
+
+            if (resourceById == null && resourceByName == null)
+            {
+                throw new CouldNotFindException(typeDescription, nameOrId, inDescription);
+            }
+
+            if (resourceById != null
+                && resourceByName != null
+                && !string.Equals(resourceById.Id, resourceByName.Id, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new CommandException(
+                    $"Ambiguous {typeDescription} reference '{nameOrId}' matches one {typeDescription} by name and another by id.");
+            }
+
+            return resourceById ?? resourceByName;
+        }
+
+        private static async Task<TResource[]> FindByNamesOrIdsOrFail<T, TResource>(this T repository,
+            Func<string, Task<TResource>> findByNameFunc, string fixedIdPrefix, string typeDescription,
+            IEnumerable<string> namesOrIds, string inDescription = "")
+            where T : IGet<TResource> where TResource : Resource
+        {
+            var results = await Task.WhenAll(namesOrIds.Select<string, Task<(string missing, TResource resource)>>(
+                async nameOrId =>
+                {
+                    try
+                    {
+                        return (null, await repository.FindByNameOrIdOrFail(findByNameFunc, fixedIdPrefix,
+                                typeDescription, nameOrId, skipLog: true, inDescription: inDescription)
+                            .ConfigureAwait(false));
+                    }
+                    catch (CouldNotFindException)
+                    {
+                        return (nameOrId, null);
+                    }
+                })).ConfigureAwait(false);
+            var missing = results.Select(r => r.missing)
+                .Where(m => m != null)
+                .ToArray();
+            if (missing.Any())
+            {
+                var missingStr = string.Join(", ", missing.Select(m => '"' + m + '"'));
+                throw new CommandException(
+                    $"The {typeDescription}{(missing.Length == 1 ? "" : "s")} {missingStr} "
+                    + $"do{(missing.Length == 1 ? "es" : "")} not exist{inDescription} or the account does not have access.");
+            }
+
+            return results.Select(r => r.resource).ToArray();
+        }
+
+        public static Task<SpaceResource> FindByNameOrIdOrFail(this ISpaceRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Spaces", "space", nameOrId);
+
+        public static Task<ProjectResource> FindByNameOrIdOrFail(this IProjectRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Projects", "project", nameOrId);
+
+        public static Task<ProjectResource[]> FindByNamesOrIdsOrFail(this IProjectRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Projects", "project", namesOrIds);
+
+        public static Task<ChannelResource> FindByNameOrIdOrFail(this IChannelRepository repo, ProjectResource project,
+            string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(project, n), "Channels", "channel",
+                nameOrId, inDescription: $" in {project.Name}");
+
+        public static Task<ChannelResource[]> FindByNamesOrIdsOrFail(this IChannelRepository repo,
+            ProjectResource project, IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(project, n), "Channels", "channel",
+                namesOrIds, inDescription: $" in {project.Name}");
+
+        public static Task<EnvironmentResource> FindByNameOrIdOrFail(this IEnvironmentRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Environments", "environment", nameOrId);
+
+        public static Task<EnvironmentResource[]> FindByNamesOrIdsOrFail(this IEnvironmentRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Environments", "environment", namesOrIds);
+
+        public static Task<TenantResource> FindByNameOrIdOrFail(this ITenantRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Tenants", "tenant", nameOrId);
+
+        public static Task<TenantResource[]> FindByNamesOrIdsOrFail(this ITenantRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Tenants", "tenant", namesOrIds);
+
+        public static Task<LifecycleResource> FindByNameOrIdOrFail(this ILifecyclesRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Lifecycles", "lifecycle", nameOrId);
+    }
+}

--- a/source/OctopusCli.sln.DotSettings
+++ b/source/OctopusCli.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lifecycles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Allows IDs to be used in place of names in all arguments to `push`, `create-release`, `deploy-release`, and `promote-release`.

* Only fetches IDs if they are in the right format.
* API calls include the `?name=...` query to minimize slurping of full pages.
* Aborts if somebody is unlucky enough to hit a name/ID ambiguity.
* Introduces repository extension methods for consistency, with error messages at least as detailed as before.
* Adds specific assertions to some tests that were passing when they shouldn't.

Note: this hasn't been tested enough to actually merge yet.