### PR TITLE
Accept IDs in arguments to push, create-release, deploy-release, promote-release

### DIFF
--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -127,7 +127,7 @@ namespace Octo.Tests.Commands
             var argsWithSpaceName = CommandLineArgs.Concat(new[] { "--space=nonExistent" });
 
             Func<Task> action = async () => await apiCommand.Execute(argsWithSpaceName.ToArray()).ConfigureAwait(false);
-            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
+            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name or id 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
         }
     }
 }

--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -127,7 +127,7 @@ namespace Octo.Tests.Commands
             var argsWithSpaceName = CommandLineArgs.Concat(new[] { "--space=nonExistent" });
 
             Func<Task> action = async () => await apiCommand.Execute(argsWithSpaceName.ToArray()).ConfigureAwait(false);
-            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name or id 'nonExistent'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
+            action.ShouldThrow<CommandException>().WithMessage("Cannot find the space with name or id 'nonExistent'. Please check the spelling and that you have permissions to view it. Please use Configuration > Test Permissions to confirm.");
         }
     }
 }

--- a/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
@@ -57,17 +57,20 @@ namespace Octo.Tests.Commands
             
             Repository.Machines.FindByNames(Arg.Any<IEnumerable<string>>(), Arg.Any<string>(), Arg.Any<object>())
                 .Returns(new List<MachineResource>());
+
+            var environmentResource = new EnvironmentResource() {Name = ValidEnvironment};
             Repository.Environments.FindByNames(
                     Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 == ValidEnvironment)),
                     Arg.Any<string>(),
                     Arg.Any<object>())
-                .Returns(new List<EnvironmentResource>() {new EnvironmentResource() {Name = ValidEnvironment}});
+                .Returns(new List<EnvironmentResource>() {environmentResource});
             Repository.Environments.FindByNames(
                     Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 != ValidEnvironment)), 
                     Arg.Any<string>(), 
                     Arg.Any<object>())
                 .Returns(new List<EnvironmentResource>());
-            
+            Repository.Environments.FindByName(ValidEnvironment).Returns(environmentResource);
+
             ClientFactory = Substitute.For<IOctopusClientFactory>();
 
             RepositoryFactory = Substitute.For<IOctopusAsyncRepositoryFactory>();

--- a/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
@@ -58,18 +58,8 @@ namespace Octo.Tests.Commands
             Repository.Machines.FindByNames(Arg.Any<IEnumerable<string>>(), Arg.Any<string>(), Arg.Any<object>())
                 .Returns(new List<MachineResource>());
 
-            var environmentResource = new EnvironmentResource() {Name = ValidEnvironment};
-            Repository.Environments.FindByNames(
-                    Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 == ValidEnvironment)),
-                    Arg.Any<string>(),
-                    Arg.Any<object>())
-                .Returns(new List<EnvironmentResource>() {environmentResource});
-            Repository.Environments.FindByNames(
-                    Arg.Is<List<string>>(arg => arg.TrueForAll(arg2 => arg2 != ValidEnvironment)), 
-                    Arg.Any<string>(), 
-                    Arg.Any<object>())
-                .Returns(new List<EnvironmentResource>());
-            Repository.Environments.FindByName(ValidEnvironment).Returns(environmentResource);
+            Repository.Environments.FindByName(ValidEnvironment)
+                .Returns(new EnvironmentResource() {Name = ValidEnvironment});
 
             ClientFactory = Substitute.For<IOctopusClientFactory>();
 

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -67,7 +67,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
             var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The tenant 'badTenant' does not exist or the account does not have access.");
+            ex.Message.Should().Be("The tenant 'badTenant' does not exist or you do not have permissions to view it.");
         }
         
         [Test]
@@ -99,7 +99,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--deployto=badEnv");
 
             var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The environment 'badEnv' does not exist or the account does not have access.");
+            ex.Message.Should().Be("The environment 'badEnv' does not exist or you do not have permissions to view it.");
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add($"--deployto=badEnv2");
 
             var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The environments 'badEnv1', 'badEnv2' do not exist or the account does not have access.");
+            ex.Message.Should().Be("The environments 'badEnv1', 'badEnv2' do not exist or you do not have permissions to view them.");
         }
     }
 }

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -66,8 +66,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--tenant=badTenant");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
-            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The tenant \"badTenant\" does not exist or the account does not have access.");
+            var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The tenant 'badTenant' does not exist or the account does not have access.");
         }
         
         [Test]
@@ -98,9 +98,25 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--releaseNumber=1.0.0");
             CommandLineArgs.Add("--deployto=badEnv");
 
-            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The environment \"badEnv\" does not exist or the account does not have access.");
+            var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The environment 'badEnv' does not exist or the account does not have access.");
         }
-        
+
+        [Test]
+        public void ShouldThrowForBadEnvironments()
+        {
+            createReleaseCommand = new CreateReleaseCommand(RepositoryFactory, new OctopusPhysicalFileSystem(Log), versionResolver, releasePlanBuilder, ClientFactory, CommandOutputProvider);
+
+            CommandLineArgs.Add("--server=https://test-server-url/api/");
+            CommandLineArgs.Add("--apikey=API-test");
+            CommandLineArgs.Add("--project=Test Project");
+            CommandLineArgs.Add("--releaseNumber=1.0.0");
+            CommandLineArgs.Add($"--deployto=badEnv1");
+            CommandLineArgs.Add($"--deployto={ValidEnvironment}");
+            CommandLineArgs.Add($"--deployto=badEnv2");
+
+            var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The environments 'badEnv1', 'badEnv2' do not exist or the account does not have access.");
+        }
     }
 }

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -33,7 +33,7 @@ namespace Octo.Tests.Commands
                 createReleaseCommand.Execute("--configfile=Commands/Resources/CreateRelease.config.txt");
             });
             
-            Assert.AreEqual("Test Project", createReleaseCommand.ProjectName);
+            Assert.AreEqual("Test Project", createReleaseCommand.ProjectNameOrId);
             Assert.AreEqual("1.0.0", createReleaseCommand.VersionNumber);
             Assert.AreEqual("Test config file.", createReleaseCommand.ReleaseNotes);
         }

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -51,7 +51,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
             var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("Unable to find matching tag from canonical tag name `badset/badtag`");
+            ex.Message.Should().Be("Unable to find matching tag from canonical tag name 'badset/badtag'.");
         }
         
         [Test]
@@ -79,11 +79,11 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--specificmachines=badMach");
+            CommandLineArgs.Add("--specificmachines=badMach,badMachB");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
-            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
-            ex.Message.Should().Be("The following specific machines could not be found: badMach");
+            var ex = Assert.ThrowsAsync<CouldNotFindException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The machines 'badMach', 'badMachB' do not exist or you do not have permissions to view them.");
         }
         
                 

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Cli.Commands.Releases;
@@ -45,10 +49,10 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--releaseNumber=1.0.0");
             CommandLineArgs.Add("--tenantTag=bad");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"\btag\b", RegexOptions.IgnoreCase));
         }
         
         [Test]
@@ -60,12 +64,12 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--tenant=bad");
+            CommandLineArgs.Add("--tenant=badTenant");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"tenant.*badTenant", RegexOptions.IgnoreCase));
         }
         
         [Test]
@@ -77,12 +81,12 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--specificmachines=bad");
+            CommandLineArgs.Add("--specificmachines=badMach");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>()
+                .Where(ex => Regex.IsMatch(ex.Message, @"machine.*badMach", RegexOptions.IgnoreCase));
         }
         
                 
@@ -95,11 +99,11 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--deployto=bad");
-            Assert.ThrowsAsync<CommandException>(async delegate
-            {
-                await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            });
+            CommandLineArgs.Add("--deployto=badEnv");
+
+            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
+            func.ShouldThrow<CommandException>().Where(ex =>
+                Regex.IsMatch(ex.Message, @"environment.*badEnv", RegexOptions.IgnoreCase));
         }
         
     }

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -47,7 +47,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--apikey=API-test");
             CommandLineArgs.Add("--project=Test Project");
             CommandLineArgs.Add("--releaseNumber=1.0.0");
-            CommandLineArgs.Add("--tenantTag=bad");
+            CommandLineArgs.Add("--tenantTag=badset/badtag");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
             Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());

--- a/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CreateReleaseCommandFixture.cs
@@ -50,9 +50,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--tenantTag=badset/badtag");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
-            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            func.ShouldThrow<CommandException>()
-                .Where(ex => Regex.IsMatch(ex.Message, @"\btag\b", RegexOptions.IgnoreCase));
+            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("Unable to find matching tag from canonical tag name `badset/badtag`");
         }
         
         [Test]
@@ -67,9 +66,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--tenant=badTenant");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
-            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            func.ShouldThrow<CommandException>()
-                .Where(ex => Regex.IsMatch(ex.Message, @"tenant.*badTenant", RegexOptions.IgnoreCase));
+            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The tenant \"badTenant\" does not exist or the account does not have access.");
         }
         
         [Test]
@@ -84,9 +82,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--specificmachines=badMach");
             CommandLineArgs.Add($"--deployto={ValidEnvironment}");
 
-            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            func.ShouldThrow<CommandException>()
-                .Where(ex => Regex.IsMatch(ex.Message, @"machine.*badMach", RegexOptions.IgnoreCase));
+            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The following specific machines could not be found: badMach");
         }
         
                 
@@ -101,9 +98,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--releaseNumber=1.0.0");
             CommandLineArgs.Add("--deployto=badEnv");
 
-            Func<Task> func = async () => await createReleaseCommand.Execute(CommandLineArgs.ToArray());
-            func.ShouldThrow<CommandException>().Where(ex =>
-                Regex.IsMatch(ex.Message, @"environment.*badEnv", RegexOptions.IgnoreCase));
+            var ex = Assert.ThrowsAsync<CommandException>(() => createReleaseCommand.Execute(CommandLineArgs.ToArray()));
+            ex.Message.Should().Be("The environment \"badEnv\" does not exist or the account does not have access.");
         }
         
     }

--- a/source/Octo.Tests/Commands/DeployReleaseCommandTestFixture.cs
+++ b/source/Octo.Tests/Commands/DeployReleaseCommandTestFixture.cs
@@ -121,8 +121,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("--progress");
             CommandLineArgs.Add("--cancelontimeout");
 
-            var environments = new List<EnvironmentResource> {new EnvironmentResource { Name = targetEnvironment}};
-            Repository.Environments.FindByNames(Arg.Any<IEnumerable<string>>()).Returns(environments);
+            var environment = new EnvironmentResource {Name = targetEnvironment};
+            Repository.Environments.FindByName(Arg.Any<string>()).Returns(environment);
             Repository.Releases.GetTemplate(Arg.Any<ReleaseResource>()).Returns(new DeploymentTemplateResource
                 {PromoteTo = new List<DeploymentPromotionTarget>() {new DeploymentPromotionTarget{Name = targetEnvironment}}});
             Repository.Releases.GetPreview(Arg.Any<DeploymentPromotionTarget>())

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -47,7 +47,7 @@ namespace Octopus.Cli.Commands
         string password;
         string username;
         readonly OctopusClientOptions clientOptions = new OctopusClientOptions();
-        string spaceName;
+        string spaceNameOrId;
 
         protected ApiCommand(IOctopusClientFactory clientFactory, IOctopusAsyncRepositoryFactory repositoryFactory, IOctopusFileSystem fileSystem, ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)
         {
@@ -69,7 +69,7 @@ namespace Octopus.Cli.Commands
             options.Add("proxy=", $"[Optional] The URI of the proxy to use, e.g., 'http://example.com:8080'.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
-            options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);
+            options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);
             options.AddLogLevelOptions();
         }
 
@@ -147,14 +147,14 @@ namespace Octopus.Cli.Commands
 
             var serverHasSpaces = await client.ForSystem().HasLink("Spaces").ConfigureAwait(false);
 
-            if (!string.IsNullOrEmpty(spaceName))
+            if (!string.IsNullOrEmpty(spaceNameOrId))
             {
                 if (!serverHasSpaces)
                 {
                     throw new CommandException($"The server {endpoint.OctopusServer} has no spaces. Try invoking the Octo tool without specifying the space name as an argument");
                 }
 
-                var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceName).ConfigureAwait(false);
+                var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceNameOrId).ConfigureAwait(false);
 
                 Repository = repositoryFactory.CreateRepository(client, RepositoryScope.ForSpace(space));
                 commandOutputProvider.Debug("Space name specified, process is now running in the context of space: {space:l}", space.Name);

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -66,7 +66,7 @@ namespace Octopus.Cli.Commands
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
             options.Add("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
             options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v => clientOptions.Timeout = TimeSpan.FromSeconds(int.Parse(v)));
-            options.Add("proxy=", $"[Optional] The URI of the proxy to use, e.g., 'http://example.com:8080'.", v => clientOptions.Proxy = v);
+            options.Add("proxy=", $"[Optional] The URL of the proxy to use, e.g., 'https://proxy.example.com'.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
             options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -56,7 +56,7 @@ namespace Octopus.Cli.Commands
             this.FileSystem = fileSystem;
 
             var options = Options.For("Common options");
-            options.Add("server=", $"[Optional] The base URL for your Octopus Server, e.g., 'http://your-octopus/'. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
+            options.Add("server=", $"[Optional] The base URL for your Octopus Server, e.g., 'https://octopus.example.com/'. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
             options.Add("apiKey=", $"[Optional] Your API key. Get this from the user profile page. Your must provide an apiKey or username and password. If the guest account is enabled, a key of API-GUEST can be used. This key can also be set in the {ApiKeyEnvVar} environment variable.", v => apiKey = v);
             options.Add("user=", $"[Optional] Username to use when authenticating with the server. Your must provide an apiKey or username and password. This Username can also be set in the {UsernameEnvVar} environment variable.", v => username = v);
             options.Add("pass=", $"[Optional] Password to use when authenticating with the server. This Password can also be set in the {PasswordEnvVar} environment variable.", v => password = v);

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -69,11 +69,9 @@ namespace Octopus.Cli.Commands
             options.Add("proxy=", $"[Optional] The URI of the proxy to use, eg http://example.com:8080.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
-            options.Add("space=", $"[Optional] The name of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);
+            options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);
             options.AddLogLevelOptions();
         }
-
-        protected ILogger Log { get; }
 
         protected string ServerBaseUrl => string.IsNullOrWhiteSpace(serverBaseUrl)
                     ? System.Environment.GetEnvironmentVariable(ServerUrlEnvVar)
@@ -156,12 +154,7 @@ namespace Octopus.Cli.Commands
                     throw new CommandException($"The server {endpoint.OctopusServer} has no spaces. Try invoking the Octo tool without specifying the space name as an argument");
                 }
 
-                commandOutputProvider.Debug("Finding space: {Space:l}", spaceName);
-                var space = await client.ForSystem().Spaces.FindByName(spaceName).ConfigureAwait(false);
-                if (space == null)
-                {
-                    throw new CommandException($"Cannot find the space with name '{spaceName}'. Please check the spelling and that the account has sufficient access to that space. Please use Configuration > Test Permissions to confirm.");
-                }
+                var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceName).ConfigureAwait(false);
 
                 Repository = repositoryFactory.CreateRepository(client, RepositoryScope.ForSpace(space));
                 commandOutputProvider.Debug("Space name specified, process is now running in the context of space: {space:l}", spaceName);

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -157,7 +157,7 @@ namespace Octopus.Cli.Commands
                 var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceName).ConfigureAwait(false);
 
                 Repository = repositoryFactory.CreateRepository(client, RepositoryScope.ForSpace(space));
-                commandOutputProvider.Debug("Space name specified, process is now running in the context of space: {space:l}", spaceName);
+                commandOutputProvider.Debug("Space name specified, process is now running in the context of space: {space:l}", space.Name);
             }
             else
             {

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -56,7 +56,7 @@ namespace Octopus.Cli.Commands
             this.FileSystem = fileSystem;
 
             var options = Options.For("Common options");
-            options.Add("server=", $"[Optional] The base URL for your Octopus Server - e.g., http://your-octopus/. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
+            options.Add("server=", $"[Optional] The base URL for your Octopus Server, e.g., 'http://your-octopus/'. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
             options.Add("apiKey=", $"[Optional] Your API key. Get this from the user profile page. Your must provide an apiKey or username and password. If the guest account is enabled, a key of API-GUEST can be used. This key can also be set in the {ApiKeyEnvVar} environment variable.", v => apiKey = v);
             options.Add("user=", $"[Optional] Username to use when authenticating with the server. Your must provide an apiKey or username and password. This Username can also be set in the {UsernameEnvVar} environment variable.", v => username = v);
             options.Add("pass=", $"[Optional] Password to use when authenticating with the server. This Password can also be set in the {PasswordEnvVar} environment variable.", v => password = v);
@@ -66,7 +66,7 @@ namespace Octopus.Cli.Commands
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
             options.Add("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
             options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v => clientOptions.Timeout = TimeSpan.FromSeconds(int.Parse(v)));
-            options.Add("proxy=", $"[Optional] The URI of the proxy to use, eg http://example.com:8080.", v => clientOptions.Proxy = v);
+            options.Add("proxy=", $"[Optional] The URI of the proxy to use, e.g., 'http://example.com:8080'.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
             options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceName = v);

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("deployto=", "Environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelName = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -35,7 +35,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (DeployToEnvironmentNames.Count == 0) throw new CommandException("Please specify an environment using the parameter: --deployto=XYZ");
+            if (DeployToEnvironmentNames.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
             if (string.IsNullOrWhiteSpace(VersionNumber)) throw new CommandException("Please specify a release version using the parameter: --version=1.0.0.0 or --version=latest for the latest release");
             if (!string.IsNullOrWhiteSpace(ChannelName) && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -21,15 +21,15 @@ namespace Octopus.Cli.Commands.Deployment
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Deployment");
-            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
             options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
-            options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelName = v);
+            options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelNameOrId = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
         public string VersionNumber { get; set; }
-        public string ChannelName { get; set; }
+        public string ChannelNameOrId { get; set; }
         public bool UpdateVariableSnapshot { get; set; }
 
 
@@ -37,16 +37,16 @@ namespace Octopus.Cli.Commands.Deployment
         {
             if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
             if (string.IsNullOrWhiteSpace(VersionNumber)) throw new CommandException("Please specify a release version using the parameter: --version=1.0.0.0 or --version=latest for the latest release");
-            if (!string.IsNullOrWhiteSpace(ChannelName) && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
+            if (!string.IsNullOrWhiteSpace(ChannelNameOrId) && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 
             await base.ValidateParameters().ConfigureAwait(false);
         }
 
         public async Task Request()
         {
-            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
-            channel = !string.IsNullOrWhiteSpace(ChannelName)
-                ? await Repository.Channels.FindByNameOrIdOrFail(project, ChannelName).ConfigureAwait(false)
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectNameOrId).ConfigureAwait(false);
+            channel = !string.IsNullOrWhiteSpace(ChannelNameOrId)
+                ? await Repository.Channels.FindByNameOrIdOrFail(project, ChannelNameOrId).ConfigureAwait(false)
                 : null;
             releaseToPromote = await RepositoryCommonQueries.GetReleaseByVersion(VersionNumber, project, channel).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -21,7 +21,7 @@ namespace Octopus.Cli.Commands.Deployment
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Deployment");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("deployto=", "Environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use when getting the release to deploy", v => ChannelName = v);
@@ -44,7 +44,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         public async Task Request()
         {
-            project = await RepositoryCommonQueries.GetProjectByName(ProjectName).ConfigureAwait(false);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
             channel = await GetChannel(project).ConfigureAwait(false);
             releaseToPromote = await RepositoryCommonQueries.GetReleaseByVersion(VersionNumber, project, channel).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelName = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
@@ -35,7 +35,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (DeployToEnvironmentNames.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
+            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
             if (string.IsNullOrWhiteSpace(VersionNumber)) throw new CommandException("Please specify a release version using the parameter: --version=1.0.0.0 or --version=latest for the latest release");
             if (!string.IsNullOrWhiteSpace(ChannelName) && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelName = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -141,18 +141,8 @@ namespace Octopus.Cli.Commands.Deployment
             } 
             
             // Make sure environment is valid
-            var environments = await Repository.Environments.FindByNames(DeployToEnvironmentNames).ConfigureAwait(false);
-            var missingEnvironment = DeployToEnvironmentNames
-                .Where(env => environments.All(env2 => !env2.Name.Equals(env, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
-            if (missingEnvironment.Count != 0)
-            {
-                throw new CommandException(
-                    $"The environment{(missingEnvironment.Count == 1 ? "" : "s")} {string.Join(", ", missingEnvironment)} " +
-                    $"do{(missingEnvironment.Count == 1 ? "es" : "")} not exist or {(missingEnvironment.Count == 1 ? "is" : "are")} misspelled");
-            }
-            
-            
+            await Repository.Environments.FindByNamesOrIdsOrFail(DeployToEnvironmentNames).ConfigureAwait(false);
+
             // Make sure the machines are valid
             await GetSpecificMachines();
 

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -66,7 +66,7 @@ namespace Octopus.Cli.Commands.Deployment
         protected List<string> SkipStepNames { get; set; }
         protected DateTimeOffset? DeployAt { get; set; }
         protected DateTimeOffset? NoDeployAfter { get; set; }
-        public string ProjectName { get; set; }
+        public string ProjectNameOrId { get; set; }
         public List<string> DeployToEnvironmentNamesOrIds { get; set; }
         public List<string> Tenants { get; set; }
         public List<string> TenantTags { get; set; }
@@ -80,7 +80,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
+            if (string.IsNullOrWhiteSpace(ProjectNameOrId)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (IsTenantedDeployment && DeployToEnvironmentNamesOrIds.Count > 1) throw new CommandException("Please specify only one environment at a time when deploying to tenants.");
             if (Tenants.Contains("*") && (Tenants.Count > 1 || TenantTags.Count > 0)) throw new CommandException("When deploying to all tenants using --tenant=* wildcard no other tenant filters can be provided");
             if (IsTenantedDeployment && !await Repository.SupportsTenants().ConfigureAwait(false))

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -122,7 +122,7 @@ namespace Octopus.Cli.Commands.Deployment
                 if (tagSetResources[parts[0]]?.Tags?.All(tag => parts[1] != tag.Name) ?? true)
                 {
                     throw new CommandException(
-                        $"Unable to find matching tag from canonical tag name `{tenantTag}`");
+                        $"Unable to find matching tag from canonical tag name '{tenantTag}'.");
                 }
             }
 
@@ -201,7 +201,7 @@ namespace Octopus.Cli.Commands.Deployment
                     SpecificMachineNames.Except(machines.Select(m => m.Name), StringComparer.OrdinalIgnoreCase).ToList();
                 if (missing.Any())
                 {
-                    throw new CommandException("The following specific machines could not be found: " + missing.ReadableJoin());
+                    throw new CouldNotFindException("machine", missing);
                 }
 
                 specificMachineIds.AddRange(machines.Select(m => m.Id));

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -174,7 +174,7 @@ namespace Octopus.Cli.Commands.Deployment
                     releaseTemplate.TenantPromotions
                         .First(t => t.Id == tenant.Id)
                         .PromoteTo
-                        .First(tt => tt.Name.Equals(environment.Name, StringComparison.CurrentCultureIgnoreCase));
+                        .First(tt => tt.Name.Equals(environment.Name, StringComparison.OrdinalIgnoreCase));
                 promotionTargets.Add(promotion);
                 return CreateDeploymentTask(project, release, promotion, specificMachineIds, excludedMachineIds, tenant);
             });
@@ -248,8 +248,8 @@ namespace Octopus.Cli.Commands.Deployment
             var releaseTemplate = await Repository.Releases.GetTemplate(release).ConfigureAwait(false);
 
             var promotingEnvironments =
-                (from environment in await Repository.Environments.FindByNamesOrIdsOrFail(DeployToEnvironmentNamesOrIds.Distinct(StringComparer.CurrentCultureIgnoreCase)).ConfigureAwait(false)
-                    let promote = releaseTemplate.PromoteTo.FirstOrDefault(p => string.Equals(p.Name, environment.Name, StringComparison.CurrentCultureIgnoreCase))
+                (from environment in await Repository.Environments.FindByNamesOrIdsOrFail(DeployToEnvironmentNamesOrIds.Distinct(StringComparer.OrdinalIgnoreCase)).ConfigureAwait(false)
+                    let promote = releaseTemplate.PromoteTo.FirstOrDefault(p => string.Equals(p.Name, environment.Name, StringComparison.OrdinalIgnoreCase))
                     select new {environment.Name, Promotion = promote}).ToList();
 
             var unknownEnvironments = promotingEnvironments.Where(p => p.Promotion == null).ToList();
@@ -289,7 +289,7 @@ namespace Octopus.Cli.Commands.Deployment
             {
                 var tenantPromotions = releaseTemplate.TenantPromotions.Where(
                     tp => tp.PromoteTo.Any(
-                        promo => promo.Name.Equals(environmentName, StringComparison.CurrentCultureIgnoreCase))).Select(tp => tp.Id).ToArray();
+                        promo => promo.Name.Equals(environmentName, StringComparison.OrdinalIgnoreCase))).Select(tp => tp.Id).ToArray();
 
                 var tentats = await Repository.Tenants.Get(tenantPromotions).ConfigureAwait(false);
                 deployableTenants.AddRange(tentats);
@@ -323,7 +323,7 @@ namespace Octopus.Cli.Commands.Deployment
                         var tenantPromo = releaseTemplate.TenantPromotions.FirstOrDefault(tp => tp.Id == dt.Id);
                         return tenantPromo == null ||
                                !tenantPromo.PromoteTo.Any(
-                                   tdt => tdt.Name.Equals(environmentName, StringComparison.CurrentCultureIgnoreCase));
+                                   tdt => tdt.Name.Equals(environmentName, StringComparison.OrdinalIgnoreCase));
                     }).Select(dt => $"'{dt.Name}'").ToList();
                     if (unDeployableTenants.Any())
                     {
@@ -347,7 +347,7 @@ namespace Octopus.Cli.Commands.Deployment
                     var deployableByTag = tenantsByTag.Where(dt =>
                     {
                         var tenantPromo = releaseTemplate.TenantPromotions.FirstOrDefault(tp => tp.Id == dt.Id);
-                        return tenantPromo != null && tenantPromo.PromoteTo.Any(tdt => tdt.Name.Equals(environmentName, StringComparison.CurrentCultureIgnoreCase));
+                        return tenantPromo != null && tenantPromo.PromoteTo.Any(tdt => tdt.Name.Equals(environmentName, StringComparison.OrdinalIgnoreCase));
                     }).Where(tenant => !deployableTenants.Any(deployable => deployable.Id == tenant.Id));
                     deployableTenants.AddRange(deployableByTag);
                 }

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -80,7 +80,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name using the parameter: --project=XYZ");
+            if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (IsTenantedDeployment && DeployToEnvironmentNames.Count > 1) throw new CommandException("Please specify only one environment at a time when deploying to tenants.");
             if (Tenants.Contains("*") && (Tenants.Count > 1 || TenantTags.Count > 0)) throw new CommandException("When deploying to all tenants using --tenant=* wildcard no other tenant filters can be provided");
             if (IsTenantedDeployment && !await Repository.SupportsTenants().ConfigureAwait(false))

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -172,7 +172,8 @@ namespace Octopus.Cli.Commands.Deployment
             {
                 var promotion =
                     releaseTemplate.TenantPromotions
-                        .First(t => t.Id == tenant.Id).PromoteTo
+                        .First(t => t.Id == tenant.Id)
+                        .PromoteTo
                         .First(tt => tt.Name.Equals(environment.Name, StringComparison.CurrentCultureIgnoreCase));
                 promotionTargets.Add(promotion);
                 return CreateDeploymentTask(project, release, promotion, specificMachineIds, excludedMachineIds, tenant);

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -18,7 +18,7 @@ namespace Octopus.Cli.Commands.Package
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Package metadata pushing");
-            options.Add("package-id=", "The ID of the package; e.g. MyCompany.MyApp", v => PackageId = v);
+            options.Add("package-id=", "The ID of the package, e.g., 'MyCompany.MyApp'.", v => PackageId = v);
             options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
             options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package.", replace => ReplaceExisting = true);

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -45,7 +45,7 @@ namespace Octopus.Cli.Commands.Releases
             options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
         }
 
         public string ChannelName { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -45,7 +45,7 @@ namespace Octopus.Cli.Commands.Releases
             options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
         }
 
         public string ChannelName { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -45,7 +45,7 @@ namespace Octopus.Cli.Commands.Releases
             options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNames.Add(v));
+            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., Production; specify this argument multiple times to deploy to multiple environments", v => DeployToEnvironmentNamesOrIds.Add(v));
         }
 
         public string ChannelName { get; set; }
@@ -153,8 +153,8 @@ namespace Octopus.Cli.Commands.Releases
             if (WhatIf)
             {
                 // We were just doing a dry run - bail out here
-                if (DeployToEnvironmentNames.Any())
-                    commandOutputProvider.Information("[WhatIf] This release would have been created using the release plan and deployed to {Environments:l}", DeployToEnvironmentNames.CommaSeperate());
+                if (DeployToEnvironmentNamesOrIds.Any())
+                    commandOutputProvider.Information("[WhatIf] This release would have been created using the release plan and deployed to {Environments:l}", DeployToEnvironmentNamesOrIds.CommaSeperate());
                 else
                     commandOutputProvider.Information("[WhatIf] This release would have been created using the release plan");
             }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Commands.Releases
             this.releasePlanBuilder = releasePlanBuilder;
 
             var options = Options.For("Release creation");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
             options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelName = v);
@@ -70,11 +70,7 @@ namespace Octopus.Cli.Commands.Releases
             var serverSupportsChannels = await ServerSupportsChannels();
             commandOutputProvider.Debug(serverSupportsChannels ? "This Octopus Server supports channels" : "This Octopus Server does not support channels");
 
-            commandOutputProvider.Debug("Finding project: {Project:l}", ProjectName);
-            
-            project = await Repository.Projects.FindByName(ProjectName).ConfigureAwait(false);
-            if (project == null)
-                throw new CouldNotFindException("a project named", ProjectName);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
 
             plan = await BuildReleasePlan(project).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -98,7 +98,7 @@ namespace Octopus.Cli.Commands.Releases
             commandOutputProvider.Write(
                 plan.IsViableReleasePlan() ? LogEventLevel.Information : LogEventLevel.Warning,
                 "Release plan for {Project:l} {Version:l}" + System.Environment.NewLine + "{Plan:l}",
-                ProjectName, versionNumber, plan.FormatAsTable()
+                project.Name, versionNumber, plan.FormatAsTable()
             );
             if (plan.HasUnresolvedSteps())
             {
@@ -132,14 +132,14 @@ namespace Octopus.Cli.Commands.Releases
 
             if (IgnoreIfAlreadyExists)
             {
-                commandOutputProvider.Debug("Checking for existing release for {Project:l} {Version:l} because you specified --ignoreexisting...", ProjectName, versionNumber);
+                commandOutputProvider.Debug("Checking for existing release for {Project:l} {Version:l} because you specified --ignoreexisting...", project.Name, versionNumber);
                 try
                 {
                     var found = await Repository.Projects.GetReleaseByVersion(project, versionNumber)
                         .ConfigureAwait(false);
                     if (found != null)
                     {
-                        commandOutputProvider.Information("A release of {Project:l} with the number {Version:l} already exists, and you specified --ignoreexisting, so we won't even attempt to create the release.", ProjectName, versionNumber);
+                        commandOutputProvider.Information("A release of {Project:l} with the number {Version:l} already exists, and you specified --ignoreexisting, so we won't even attempt to create the release.", project.Name, versionNumber);
                         return;
                     }
                 }

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -104,10 +104,10 @@ namespace Octopus.Cli.Commands.Releases
 
             var firstChannelPage = await Repository.Projects.GetChannels(project).ConfigureAwait(false);
             var allChannels = await firstChannelPage.GetAllPages(Repository).ConfigureAwait(false);
-            var channels = allChannels.Where(c => ChannelNames.Contains(c.Name, StringComparer.CurrentCultureIgnoreCase))
+            var channels = allChannels.Where(c => ChannelNames.Contains(c.Name, StringComparer.OrdinalIgnoreCase))
                 .ToArray();
 
-            var notFoundChannels = ChannelNames.Except(channels.Select(c => c.Name), StringComparer.CurrentCultureIgnoreCase).ToArray();
+            var notFoundChannels = ChannelNames.Except(channels.Select(c => c.Name), StringComparer.OrdinalIgnoreCase).ToArray();
             if (notFoundChannels.Any())
                 throw new CouldNotFindException("the channels named", notFoundChannels.CommaSeperate());
 

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -22,8 +22,8 @@ namespace Octopus.Cli.Commands.Releases
         {
             var options = Options.For("Release Promotion");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., Staging", v => FromEnvironmentName = v);
-            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., Production", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentName = v);
+            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -21,7 +21,7 @@ namespace Octopus.Cli.Commands.Releases
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Release Promotion");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("from=", "Name of the environment to get the current deployment from, e.g., Staging", v => FromEnvironmentName = v);
             options.Add("to=|deployto=", "Environment to deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
@@ -40,11 +40,7 @@ namespace Octopus.Cli.Commands.Releases
 
         public async Task Request()
         {
-            commandOutputProvider.Debug("Finding project: {Project:l}", ProjectName);
-            
-            project = await Repository.Projects.FindByName(ProjectName).ConfigureAwait(false);
-            if (project == null)
-                throw new CouldNotFindException("a project named", ProjectName);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
 
             commandOutputProvider.Debug("Finding environment: {Environment:l}", FromEnvironmentName);
             

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -21,28 +21,28 @@ namespace Octopus.Cli.Commands.Releases
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Release Promotion");
-            options.Add("project=", "Name or ID of the project", v => ProjectName = v);
-            options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentName = v);
+            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentNameOrId = v);
             options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
-        public string FromEnvironmentName { get; set; }
+        public string FromEnvironmentNameOrId { get; set; }
         public bool UpdateVariableSnapshot { get; set; }
 
         protected override async Task ValidateParameters()
         {
             if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
-            if (string.IsNullOrWhiteSpace(FromEnvironmentName)) throw new CommandException("Please specify a source environment name or ID using the parameter: --from=XYZ");
+            if (string.IsNullOrWhiteSpace(FromEnvironmentNameOrId)) throw new CommandException("Please specify a source environment name or ID using the parameter: --from=XYZ");
 
             await base.ValidateParameters().ConfigureAwait(false);
         }
 
         public async Task Request()
         {
-            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectName).ConfigureAwait(false);
+            project = await Repository.Projects.FindByNameOrIdOrFail(ProjectNameOrId).ConfigureAwait(false);
 
-            environment = await Repository.Environments.FindByNameOrIdOrFail(FromEnvironmentName).ConfigureAwait(false);
+            environment = await Repository.Environments.FindByNameOrIdOrFail(FromEnvironmentNameOrId).ConfigureAwait(false);
 
             var dashboard = await Repository.Dashboards.GetDynamicDashboard(new[] {project.Id}, new[] {environment.Id}).ConfigureAwait(false);
             var dashboardItem = dashboard.Items.Where(e => e.EnvironmentId == environment.Id && e.ProjectId == project.Id)

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -23,7 +23,7 @@ namespace Octopus.Cli.Commands.Releases
             var options = Options.For("Release Promotion");
             options.Add("project=", "Name or ID of the project", v => ProjectName = v);
             options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., Staging", v => FromEnvironmentName = v);
-            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., Production", v => DeployToEnvironmentNames.Add(v));
+            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., Production", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Commands.Releases
 
         protected override async Task ValidateParameters()
         {
-            if (DeployToEnvironmentNames.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
+            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
             if (string.IsNullOrWhiteSpace(FromEnvironmentName)) throw new CommandException("Please specify a source environment name or ID using the parameter: --from=XYZ");
 
             await base.ValidateParameters().ConfigureAwait(false);

--- a/source/Octopus.Cli/Importers/ProjectImporter.cs
+++ b/source/Octopus.Cli/Importers/ProjectImporter.cs
@@ -515,7 +515,7 @@ namespace Octopus.Cli.Importers
                 }
                 else
                 {
-                    Log.Debug($"Channel `{channel.Name}` does not exist, a new channel will be created");
+                    Log.Debug($"Channel '{channel.Name}' does not exist, a new channel will be created");
                     channel.ProjectId = importedProject.Id;
                     if (channel.LifecycleId != null)
                     {

--- a/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
+++ b/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
@@ -3,7 +3,7 @@
     public class CouldNotFindException : CommandException
     {
         public CouldNotFindException(string what)
-            : base("Could not find " + what  + "; either it does not exist or you lack permissions to view it.")
+            : base("Could not find " + what + "; either it does not exist or you lack permissions to view it.")
         {
         }
 
@@ -12,5 +12,10 @@
         {
         }
 
+        public CouldNotFindException(string typeDescription, string nameOrId, string inDescription) : base(
+            $"Cannot find the {typeDescription} with name or id '{nameOrId}'{inDescription}. "
+            + $"Please check the spelling and that the account has sufficient access to that {typeDescription}. Please use Configuration > Test Permissions to confirm.")
+        {
+        }
     }
 }

--- a/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
+++ b/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
@@ -16,16 +16,16 @@ namespace Octopus.Cli.Infrastructure
         }
 
         public CouldNotFindException(string resourceTypeDisplayName, string nameOrId,
-            string enclosingContextDescription) : base(
+            string enclosingContextDescription = "") : base(
             $"Cannot find the {resourceTypeDisplayName} with name or id '{nameOrId}'{enclosingContextDescription}. "
-            + $"Please check the spelling and that the account has sufficient access to that {resourceTypeDisplayName}. Please use Configuration > Test Permissions to confirm.")
+            + $"Please check the spelling and that you have permissions to view it. Please use Configuration > Test Permissions to confirm.")
         {
         }
 
         public CouldNotFindException(string resourceTypeDisplayName, ICollection<string> missingNamesOrIds,
-            string enclosingContextDescription) : base(
+            string enclosingContextDescription = "") : base(
             $"The {resourceTypeDisplayName}{(missingNamesOrIds.Count == 1 ? "" : "s")} {string.Join(", ", missingNamesOrIds.Select(m => "'" + m + "'"))} "
-            + $"do{(missingNamesOrIds.Count == 1 ? "es" : "")} not exist{enclosingContextDescription} or the account does not have access.")
+            + $"do{(missingNamesOrIds.Count == 1 ? "es" : "")} not exist{enclosingContextDescription} or you do not have permissions to view {(missingNamesOrIds.Count == 1 ? "it" : "them")}.")
         {
         }
     }

--- a/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
+++ b/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
@@ -1,4 +1,7 @@
-﻿namespace Octopus.Cli.Infrastructure
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Octopus.Cli.Infrastructure
 {
     public class CouldNotFindException : CommandException
     {
@@ -16,6 +19,13 @@
             string enclosingContextDescription) : base(
             $"Cannot find the {resourceTypeDisplayName} with name or id '{nameOrId}'{enclosingContextDescription}. "
             + $"Please check the spelling and that the account has sufficient access to that {resourceTypeDisplayName}. Please use Configuration > Test Permissions to confirm.")
+        {
+        }
+
+        public CouldNotFindException(string resourceTypeDisplayName, ICollection<string> missingNamesOrIds,
+            string enclosingContextDescription) : base(
+            $"The {resourceTypeDisplayName}{(missingNamesOrIds.Count == 1 ? "" : "s")} {string.Join(", ", missingNamesOrIds.Select(m => "'" + m + "'"))} "
+            + $"do{(missingNamesOrIds.Count == 1 ? "es" : "")} not exist{enclosingContextDescription} or the account does not have access.")
         {
         }
     }

--- a/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
+++ b/source/Octopus.Cli/Infrastructure/CouldNotFindException.cs
@@ -12,9 +12,10 @@
         {
         }
 
-        public CouldNotFindException(string typeDescription, string nameOrId, string inDescription) : base(
-            $"Cannot find the {typeDescription} with name or id '{nameOrId}'{inDescription}. "
-            + $"Please check the spelling and that the account has sufficient access to that {typeDescription}. Please use Configuration > Test Permissions to confirm.")
+        public CouldNotFindException(string resourceTypeDisplayName, string nameOrId,
+            string enclosingContextDescription) : base(
+            $"Cannot find the {resourceTypeDisplayName} with name or id '{nameOrId}'{enclosingContextDescription}. "
+            + $"Please check the spelling and that the account has sufficient access to that {resourceTypeDisplayName}. Please use Configuration > Test Permissions to confirm.")
         {
         }
     }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Sprache" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.3.0" />
     <PackageReference Include="Autofac" Version="4.6.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Octopus.Cli/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Cli/Util/RepositoryExtensions.cs
@@ -102,10 +102,7 @@ namespace Octopus.Cli.Util
                 .ToArray();
             if (missingNamesOrIds.Any())
             {
-                var missingStr = string.Join(", ", missingNamesOrIds.Select(m => '"' + m + '"'));
-                throw new CommandException(
-                    $"The {resourceTypeDisplayName}{(missing.Length == 1 ? "" : "s")} {missingStr} "
-                    + $"do{(missing.Length == 1 ? "es" : "")} not exist{enclosingContextDescription} or the account does not have access.");
+                throw new CouldNotFindException(resourceTypeDisplayName, missingNamesOrIds, enclosingContextDescription);
             }
 
             if (!skipLog)

--- a/source/Octopus.Cli/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Cli/Util/RepositoryExtensions.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Octopus.Cli.Infrastructure;
+using Octopus.Client.Exceptions;
+using Octopus.Client.Logging;
+using Octopus.Client.Model;
+using Octopus.Client.Repositories.Async;
+
+namespace Octopus.Cli.Util
+{
+    public static class RepositoryExtensions
+    {
+        private static readonly ILog Logger = LogProvider.GetLogger(typeof(RepositoryExtensions));
+
+        private static async Task<TResource> FindByNameOrIdOrFail<T, TResource>(this T repository,
+            Func<string, Task<TResource>> findByNameFunc, string fixedIdPrefix, string typeDescription, string nameOrId,
+            string inDescription = "", bool skipLog = false)
+            where T : IGet<TResource> where TResource : Resource
+        {
+            if (!skipLog)
+            {
+                Logger.Debug($"Finding {typeDescription}: {nameOrId}");
+            }
+
+            TResource resourceById;
+            if (!Regex.IsMatch(nameOrId, $@"^{Regex.Escape(fixedIdPrefix)}-\d+$",
+                RegexOptions.Compiled | RegexOptions.IgnoreCase))
+            {
+                resourceById = null;
+            }
+            else
+            {
+                try
+                {
+                    resourceById = await repository.Get(nameOrId)
+                        .ConfigureAwait(false);
+                }
+                catch (OctopusResourceNotFoundException)
+                {
+                    resourceById = null;
+                }
+            }
+
+            var resourceByName = await findByNameFunc(nameOrId)
+                .ConfigureAwait(false);
+
+            if (resourceById == null && resourceByName == null)
+            {
+                throw new CouldNotFindException(typeDescription, nameOrId, inDescription);
+            }
+
+            if (resourceById != null
+                && resourceByName != null
+                && !string.Equals(resourceById.Id, resourceByName.Id, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new CommandException(
+                    $"Ambiguous {typeDescription} reference '{nameOrId}' matches one {typeDescription} by name and another by id.");
+            }
+
+            return resourceById ?? resourceByName;
+        }
+
+        private static async Task<TResource[]> FindByNamesOrIdsOrFail<T, TResource>(this T repository,
+            Func<string, Task<TResource>> findByNameFunc, string fixedIdPrefix, string typeDescription,
+            IEnumerable<string> namesOrIds, string inDescription = "")
+            where T : IGet<TResource> where TResource : Resource
+        {
+            var results = await Task.WhenAll(namesOrIds.Select<string, Task<(string missing, TResource resource)>>(
+                async nameOrId =>
+                {
+                    try
+                    {
+                        return (null, await repository.FindByNameOrIdOrFail(findByNameFunc, fixedIdPrefix,
+                                typeDescription, nameOrId, skipLog: true, inDescription: inDescription)
+                            .ConfigureAwait(false));
+                    }
+                    catch (CouldNotFindException)
+                    {
+                        return (nameOrId, null);
+                    }
+                })).ConfigureAwait(false);
+            var missing = results.Select(r => r.missing)
+                .Where(m => m != null)
+                .ToArray();
+            if (missing.Any())
+            {
+                var missingStr = string.Join(", ", missing.Select(m => '"' + m + '"'));
+                throw new CommandException(
+                    $"The {typeDescription}{(missing.Length == 1 ? "" : "s")} {missingStr} "
+                    + $"do{(missing.Length == 1 ? "es" : "")} not exist{inDescription} or the account does not have access.");
+            }
+
+            return results.Select(r => r.resource).ToArray();
+        }
+
+        public static Task<SpaceResource> FindByNameOrIdOrFail(this ISpaceRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Spaces", "space", nameOrId);
+
+        public static Task<ProjectResource> FindByNameOrIdOrFail(this IProjectRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Projects", "project", nameOrId);
+
+        public static Task<ProjectResource[]> FindByNamesOrIdsOrFail(this IProjectRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Projects", "project", namesOrIds);
+
+        public static Task<ChannelResource> FindByNameOrIdOrFail(this IChannelRepository repo, ProjectResource project,
+            string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(project, n), "Channels", "channel",
+                nameOrId, inDescription: $" in {project.Name}");
+
+        public static Task<ChannelResource[]> FindByNamesOrIdsOrFail(this IChannelRepository repo,
+            ProjectResource project, IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(project, n), "Channels", "channel",
+                namesOrIds, inDescription: $" in {project.Name}");
+
+        public static Task<EnvironmentResource> FindByNameOrIdOrFail(this IEnvironmentRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Environments", "environment", nameOrId);
+
+        public static Task<EnvironmentResource[]> FindByNamesOrIdsOrFail(this IEnvironmentRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Environments", "environment", namesOrIds);
+
+        public static Task<TenantResource> FindByNameOrIdOrFail(this ITenantRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Tenants", "tenant", nameOrId);
+
+        public static Task<TenantResource[]> FindByNamesOrIdsOrFail(this ITenantRepository repo,
+            IEnumerable<string> namesOrIds)
+            => repo.FindByNamesOrIdsOrFail(n => repo.FindByName(n), "Tenants", "tenant", namesOrIds);
+
+        public static Task<LifecycleResource> FindByNameOrIdOrFail(this ILifecyclesRepository repo, string nameOrId)
+            => repo.FindByNameOrIdOrFail(n => repo.FindByName(n), "Lifecycles", "lifecycle", nameOrId);
+    }
+}

--- a/source/Octopus.Cli/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Cli/Util/RepositoryExtensions.cs
@@ -41,8 +41,16 @@ namespace Octopus.Cli.Util
                 }
             }
 
-            var resourceByName = await findByNameFunc(nameOrId)
-                .ConfigureAwait(false);
+            TResource resourceByName;
+            try
+            {
+                resourceByName = await findByNameFunc(nameOrId)
+                    .ConfigureAwait(false);
+            }
+            catch (OctopusResourceNotFoundException)
+            {
+                resourceByName = null;
+            }
 
             if (resourceById == null && resourceByName == null)
             {

--- a/source/Octopus.Cli/Util/RepositoryExtensions.cs
+++ b/source/Octopus.Cli/Util/RepositoryExtensions.cs
@@ -62,7 +62,7 @@ namespace Octopus.Cli.Util
                 && !string.Equals(resourceById.Id, resourceByName.Id, StringComparison.OrdinalIgnoreCase))
             {
                 throw new CommandException(
-                    $"Ambiguous {resourceTypeDisplayName} reference '{nameOrId}' matches one {resourceTypeDisplayName} by name and another by id.");
+                    $"Ambiguous {resourceTypeDisplayName} reference '{nameOrId}' matches both '{resourceById.Name}' ({resourceById.Id}) and '{resourceByName.Name}' ({resourceByName.Id}).");
             }
 
             var found = resourceById ?? resourceByName;

--- a/source/OctopusCli.sln.DotSettings
+++ b/source/OctopusCli.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lifecycles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Allows IDs to be used in place of names in all arguments to `push`, `create-release`, `deploy-release`, and `promote-release`.

* Only fetches IDs if they are in the right format.
* API calls include the `?name=...` query to minimize slurping of full pages.
* Aborts if somebody is unlucky enough to hit a name/ID ambiguity.
* Introduces repository extension methods for consistency, with logging & error messages slightly more detailed than before.
* Adds specific assertions to some tests that were passing in situations where they shouldn't.