### PR TITLE
If log entry line is a TeamCity service message, output line as-is. 

### DIFF
--- a/source/Octopus.Cli/Commands/Deployment/TaskOutputProgressPrinter.cs
+++ b/source/Octopus.Cli/Commands/Deployment/TaskOutputProgressPrinter.cs
@@ -107,7 +107,8 @@ namespace Octopus.Cli.Commands.Deployment
                     // If a customer writes custom TeamCity service messages in their scripts we should output it as-is,
                     // otherwise they won't be treated as a service message in TeamCity.
                     // https://github.com/OctopusDeploy/OctopusCLI/issues/7
-                    if (IsTeamCityServiceMessage(line))
+                    var isAlreadyTeamCityServiceMessage = line.StartsWith("##teamcity", StringComparison.OrdinalIgnoreCase);
+                    if (isAlreadyTeamCityServiceMessage)
                     {
                         commandOutputProvider.Information(line);
                     }
@@ -153,11 +154,6 @@ namespace Octopus.Cli.Commands.Deployment
                 case "Warning": return "WARNING";
             }
             return "NORMAL";
-        }
-
-        static bool IsTeamCityServiceMessage(string line)
-        {
-            return line.StartsWith("##teamcity", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Before:
```
Creating release...
Release 1.0.18 created successfully!
##teamcity[setParameter name='octo.releaseNumber' value='1.0.18']
Deploying TeamCity Service Message test "1.0.18" to: Dev (Guided Failure: Not Enabled)
Waiting for 1 deployment(s) to complete....
##teamcity[blockOpened name='Success: Acquire packages']
##teamcity[message text='Acquiring packages' status='NORMAL']
##teamcity[message text='Making a list of packages to acquire' status='NORMAL']
##teamcity[message text='All packages have been acquired' status='NORMAL']
##teamcity[blockOpened name='Success: Octopus Server']
##teamcity[blockOpened name='Success: Download package MyScript v1.0.1 from Octopus Server (built-in)']
##teamcity[message text='Package MyScript v1.0.1 was found in cache. No need to download from feed.' status='NORMAL']
##teamcity[message text='Successfully downloaded MyScript 1.0.1 (275 B)' status='NORMAL']
##teamcity[blockClosed name='Success: Download package MyScript v1.0.1 from Octopus Server (built-in)']
##teamcity[blockClosed name='Success: Octopus Server']
##teamcity[blockClosed name='Success: Acquire packages']
##teamcity[blockOpened name='Success: Step 1: Output service message']
##teamcity[blockOpened name='Success: Octopus Server']
##teamcity[message text='Extracting package |'C:\OctopusDev\enh-workitems\Server\Packages\Spaces-1\feeds-builtin\MyScript\MyScript.1.0.1.zip|' to |'C:\OctopusDev\enh-workitems\Server\Work\20190628004614-10094-80|'' status='NORMAL']
##teamcity[message text='hello world' status='NORMAL']
 <!-- TeamCity `setParameter` type Service message output as a TeamCity `message` type Service Message instead of as logged -->
##teamcity[message text='##teamcity|[setParameter name=|'ddd|' value=|'fff|'|]' status='NORMAL']
<!-- END -->
##teamcity[message text='bye #{MissingVariable}' status='NORMAL']
##teamcity[blockClosed name='Success: Octopus Server']
##teamcity[blockClosed name='Success: Step 1: Output service message']
Deploy TeamCity Service Message test release 1.0.18 to Dev: Success
Done!
```

After:
```
Creating release...
Release 1.0.19 created successfully!
##teamcity[setParameter name='octo.releaseNumber' value='1.0.19']
Deploying TeamCity Service Message test "1.0.19" to: Dev (Guided Failure: Not Enabled)
Waiting for 1 deployment(s) to complete....
##teamcity[blockOpened name='Success: Acquire packages']
##teamcity[message text='Acquiring packages' status='NORMAL']
##teamcity[message text='Making a list of packages to acquire' status='NORMAL']
##teamcity[message text='All packages have been acquired' status='NORMAL']
##teamcity[blockOpened name='Success: Octopus Server']
##teamcity[blockOpened name='Success: Download package MyScript v1.0.1 from Octopus Server (built-in)']
##teamcity[message text='Package MyScript v1.0.1 was found in cache. No need to download from feed.' status='NORMAL']
##teamcity[message text='Successfully downloaded MyScript 1.0.1 (275 B)' status='NORMAL']
##teamcity[blockClosed name='Success: Download package MyScript v1.0.1 from Octopus Server (built-in)']
##teamcity[blockClosed name='Success: Octopus Server']
##teamcity[blockClosed name='Success: Acquire packages']
##teamcity[blockOpened name='Success: Step 1: Output service message']
##teamcity[blockOpened name='Success: Octopus Server']
##teamcity[message text='Extracting package |'C:\OctopusDev\enh-workitems\Server\Packages\Spaces-1\feeds-builtin\MyScript\MyScript.1.0.1.zip|' to |'C:\OctopusDev\enh-workitems\Server\Work\20190628004821-10095-81|'' status='NORMAL']
##teamcity[message text='hello world' status='NORMAL']
<!-- TeamCity `setParameter` type Service Message output as logged -->
##teamcity[setParameter name='ddd' value='fff']
<!-- END -->
##teamcity[message text='bye #{MissingVariable}' status='NORMAL']
##teamcity[blockClosed name='Success: Octopus Server']
##teamcity[blockClosed name='Success: Step 1: Output service message']
Deploy TeamCity Service Message test release 1.0.19 to Dev: Success
Done!
```

Fixes #7