### PR TITLE
Added overwrite-mode to the push and push metadata commands

### DIFF
--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode6" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode8" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="6.8.1" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode6" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode8" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode9" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -28,7 +28,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode9" />
+    <PackageReference Include="Octopus.Client" Version="6.9.0" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -25,7 +25,7 @@ namespace Octopus.Cli.Commands.Package
             options.Add("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
                 package => Packages.Add(EnsurePackageExists(fileSystem, package)));
             options.Add("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
-            options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", 
+            options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", 
                 replace => OverwriteMode = OverwriteMode.OverwriteExisting);
             options.Add("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",
                 v =>

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -24,7 +24,7 @@ namespace Octopus.Cli.Commands.Package
             var options = Options.For("Package pushing");
             options.Add("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
                 package => Packages.Add(EnsurePackageExists(fileSystem, package)));
-            options.Add("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode));
+            options.Add("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
             options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", 
                 replace => OverwriteMode = OverwriteMode.OverwriteExisting);
             options.Add("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -8,7 +8,7 @@ using Octopus.Cli.Model;
 using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
 using Octopus.Client;
-using Serilog;
+using Octopus.Client.Model;
 
 namespace Octopus.Cli.Commands.Package
 {
@@ -24,8 +24,9 @@ namespace Octopus.Cli.Commands.Package
             var options = Options.For("Package pushing");
             options.Add("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
                 package => Packages.Add(EnsurePackageExists(fileSystem, package)));
-            options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package.", 
-                replace => ReplaceExisting = true);
+            options.Add("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode));
+            options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", 
+                replace => OverwriteMode = OverwriteMode.OverwriteExisting);
             options.Add("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",
                 v =>
                 {
@@ -38,7 +39,7 @@ namespace Octopus.Cli.Commands.Package
         }
 
         public HashSet<string> Packages { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase); 
-        public bool ReplaceExisting { get; set; }
+        public OverwriteMode OverwriteMode { get; set; }
         public bool UseDeltaCompression { get; set; } = true;
  
         public async Task Request()
@@ -54,7 +55,7 @@ namespace Octopus.Cli.Commands.Package
                     using (var fileStream = FileSystem.OpenFile(package, FileAccess.Read))
                     {
                         await Repository.BuiltInPackageRepository
-                            .PushPackage(Path.GetFileName(package), fileStream, ReplaceExisting, UseDeltaCompression)
+                            .PushPackage(Path.GetFileName(package), fileStream, OverwriteMode, UseDeltaCompression)
                             .ConfigureAwait(false);
                     }
 

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -5,6 +5,7 @@ using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
 using Octopus.Client;
+using Octopus.Client.Model;
 using Octopus.Client.Model.PackageMetadata;
 
 namespace Octopus.Cli.Commands.Package
@@ -21,13 +22,14 @@ namespace Octopus.Cli.Commands.Package
             options.Add("package-id=", "The ID of the package; e.g. MyCompany.MyApp", v => PackageId = v);
             options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
-            options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package.", replace => ReplaceExisting = true);
+            options.Add("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode));
+            options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
         }
 
         public string PackageId { get; set; }
         public string Version { get; set; }
         public string MetadataFile { get; set; }
-        public bool ReplaceExisting { get; set; }
+        public OverwriteMode OverwriteMode { get; set; }
 
         public async Task Request()
         {
@@ -39,7 +41,7 @@ namespace Octopus.Cli.Commands.Package
             var fileContent = FileSystem.ReadAllText(MetadataFile);
             var octopusPackageMetadata = JsonConvert.DeserializeObject<OctopusPackageMetadata>(fileContent);
 
-            resultResource = await Repository.PackageMetadataRepository.Push(PackageId, Version, octopusPackageMetadata, ReplaceExisting);
+            resultResource = await Repository.PackageMetadataRepository.Push(PackageId, Version, octopusPackageMetadata, OverwriteMode);
         }
 
         public void PrintDefaultOutput()

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -23,7 +23,7 @@ namespace Octopus.Cli.Commands.Package
             options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
             options.Add("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
-            options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
+            options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package metadata. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
         }
 
         public string PackageId { get; set; }

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Package
             options.Add("package-id=", "The ID of the package; e.g. MyCompany.MyApp", v => PackageId = v);
             options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
-            options.Add("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode));
+            options.Add("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
             options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version, passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
         }
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -20,14 +20,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.Common" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Frameworks" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode9" />
+    <PackageReference Include="Octopus.Client" Version="6.9.0" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode6" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode8" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="6.8.1" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode6" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode8" />
+    <PackageReference Include="Octopus.Client" Version="6.8.2-enh-overwritemode9" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />


### PR DESCRIPTION
Adding `--overwrite-mode`, to replace the `--replace-existing` flag. Adds the ability for the caller to IgnoreExisting.

Relates to OctopusDeploy/Octopus-TeamCity#18