### PR TITLE
Metadata push validation

### DIFF
--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="7.0.0" />
+    <PackageReference Include="Octopus.Client" Version="7.0.2-enh-buildinfoerror10" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="7.0.2-enh-buildinfoerror10" />
+    <PackageReference Include="Octopus.Client" Version="7.0.2" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -33,8 +33,15 @@ namespace Octopus.Cli.Commands.Package
 
         public async Task Request()
         {
+            if (string.IsNullOrEmpty(MetadataFile))
+                throw new CommandException("Please specify the metadata file.");
+            if (string.IsNullOrEmpty(PackageId))
+                throw new CommandException("Please specify the package id.");
+            if (string.IsNullOrEmpty(Version))
+                throw new CommandException("Please specify the package version.");
+
             if (!FileSystem.FileExists(MetadataFile))
-                throw new CommandException("Metadata file does not exist");
+                throw new CommandException($"Metadata file '{MetadataFile}' does not exist");
 
             commandOutputProvider.Debug("Pushing package metadata: {PackageId}...", PackageId);
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="7.0.2-enh-buildinfoerror10" />
+    <PackageReference Include="Octopus.Client" Version="7.0.2" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="7.0.0" />
+    <PackageReference Include="Octopus.Client" Version="7.0.2-enh-buildinfoerror10" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />


### PR DESCRIPTION
Updates OctopusClients to get nicer check for push-metadata support on Octopus Server.

```
PS > .\octo.exe push-metadata --server=htps://octopus.example.com --apikey API-XXXXXXX --metadata-file foo.txt --package-id foo --version "1.2.3"                                                                                                                                                                                                               Detected automation environment: "NoneOrUnknown"
Process will run in backwards compatible mode for older versions of Octopus Server
Handshaking with Octopus Server: https://octopus.example.com
Handshake successful. Octopus version: 2018.10.1; API version: 3.0.0
Authenticated as: admin
Pushing package metadata: "foo"...
Pushing build information/package metadata requires Octopus version 2019.4.1 or newer
Error from Octopus Server (HTTP 501 NotImplemented) 
```

Also add parameter validation for push-metadata arguments