### PR TITLE
Changed the default package wildcard behavior for `create-release`

### DIFF
--- a/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
@@ -171,5 +171,23 @@ namespace Octo.Tests.Commands
 
             Assert.That(resolver.ResolveVersion("Step", "Package1", null), Is.EqualTo("1.0.0"));
         }
+        
+        [Test]
+        public void ShouldHandleOnlyStepSpecifiedWithDefaultPackageAndExplicitDefaultSpecified()
+        {
+            resolver.Add("Step::1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", null), Is.EqualTo("1.0.0"));
+        }
+        
+        [Test]
+        public void ShouldHandlePackageReferencesOnTheSameStepWithExplicitDefaultPackageReference()
+        {
+            resolver.Add("Step::1.0.0");
+            resolver.Add("Step:foo:1.0.1");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", null), Is.EqualTo("1.0.0"));
+            Assert.That(resolver.ResolveVersion("Step", "Package1", "foo"), Is.EqualTo("1.0.1"));
+        }
     }
 }

--- a/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
@@ -85,12 +85,9 @@ namespace Octo.Tests.Commands
         {
             resolver.Add("PackageA:Package2:2.0.0");
             resolver.Add("Step:Package2:3.0.0");
-            resolver.Add("Step:4.0.0");
-            resolver.Add("Package2:5.0.0");
             resolver.Add("PackageA:*:1.0.0");
             resolver.Add("*:Package1:1.0.0-alpha1");
             resolver.Add("*=Package1=1.0.0-alpha1");
-            resolver.Add("*=*=1.0.0-beta");
             resolver.Add("*=6.0.0");
 
             // This is an exact match. We prioritise step names over package names
@@ -99,12 +96,6 @@ namespace Octo.Tests.Commands
             Assert.That(resolver.ResolveVersion("Step", "PackageUnknown", "Package2"), Is.EqualTo("3.0.0"));
             // This is an exact match to the package name
             Assert.That(resolver.ResolveVersion("StepUnknown", "PackageA", "Package2"), Is.EqualTo("2.0.0"));
-            // This is an exact match to the unnamed package version by step id
-            Assert.That(resolver.ResolveVersion("Step", "PackageWhatever"), Is.EqualTo("4.0.0"));
-            // This is an exact match to the unnamed package version by package id
-            Assert.That(resolver.ResolveVersion("StepUnknown", "Package2"), Is.EqualTo("5.0.0"));
-            // Unnamed packages also match the wildcard. In this case it is the wildcard for the unnamed packages
-            Assert.That(resolver.ResolveVersion("StepUnknown", "PackageA"), Is.EqualTo("6.0.0"));
             // This will match the wildcard step but fixed package name version, because we treat the
             // package reference name as more specific
             Assert.That(resolver.ResolveVersion("Step", "PackageA", "Package1"), Is.EqualTo("1.0.0-alpha1"));
@@ -114,7 +105,7 @@ namespace Octo.Tests.Commands
             // specific than the default
             Assert.That(resolver.ResolveVersion("Step", "PackageB", "Package1"), Is.EqualTo("1.0.0-alpha1"));
             // This will match the default (i.e. the double wildcard)
-            Assert.That(resolver.ResolveVersion("StepWhatever", "PackageB", "PackageUnknown"), Is.EqualTo("1.0.0-beta"));
+            Assert.That(resolver.ResolveVersion("StepWhatever", "PackageB", "PackageUnknown"), Is.EqualTo("6.0.0"));
         }
 
         [Test]
@@ -147,6 +138,38 @@ namespace Octo.Tests.Commands
             resolver.Add("PackageId", "Package1", "1.2.0");
 
             Assert.That(resolver.ResolveVersion("StepName", "PackageId", "Package1"), Is.EqualTo("1.2.0"));
+        }
+        
+        [Test]
+        public void ShouldHandleNoStepSpecifiedWithNamedReference()
+        {
+            resolver.Add("Package1:1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", "Package1"), Is.EqualTo("1.0.0"));
+        }
+        
+        [Test]
+        public void ShouldHandleNoStepSpecifiedWithDefaultPackageReferenceName()
+        {
+            resolver.Add("Package1:1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", null), Is.EqualTo("1.0.0"));
+        }
+        
+        [Test]
+        public void ShouldHandleOnlyStepSpecifiedWithNamedReference()
+        {
+            resolver.Add("Step:1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", "Package1"), Is.EqualTo("1.0.0"));
+        }
+        
+        [Test]
+        public void ShouldHandleOnlyStepSpecifiedWithDefaultPackageReferenceName()
+        {
+            resolver.Add("Step:1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "Package1", null), Is.EqualTo("1.0.0"));
         }
     }
 }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -35,7 +35,7 @@ namespace Octopus.Cli.Commands.Releases
             options.Add("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
             options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
-            options.Add("package=", "[Optional] Version number to use for a package in the release. Format: StepName:Version or PackageID:Version or StepName:PackageName:Version. StepName, PackageID, and PackageName can be replaced with an asterisk.", v => versionResolver.Add(v));
+            options.Add("package=", "[Optional] Version number to use for a package in the release. Format: StepName:Version or PackageID:Version or StepName:PackageName:Version. StepName, PackageID, and PackageName can be replaced with an asterisk. An asterisk will be assumed for StepName, PackageID, or PackageName if they are omitted.", v => versionResolver.Add(v));
             options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => {v.CheckForIllegalPathCharacters("packagesFolder"); versionResolver.AddFolder(v);});
             options.Add("releasenotes=", "[Optional] Release Notes for the new release. Styling with Markdown is supported.", v => ReleaseNotes = v);
             options.Add("releasenotesfile=", "[Optional] Path to a file that contains Release Notes for the new release. Supports Markdown files.", ReadReleaseNotesFromFile);

--- a/source/Octopus.Cli/Commands/Releases/IPackageVersionResolver.cs
+++ b/source/Octopus.Cli/Commands/Releases/IPackageVersionResolver.cs
@@ -1,23 +1,29 @@
+using Octopus.Client.Model;
+
 namespace Octopus.Cli.Commands.Releases
 {
     public interface IPackageVersionResolver
     {
         void AddFolder(string folderPath);
-        void Add(string stepNameAndVersion);
+        void Add(string stepNameOrPackageIdAndVersion);
+        
         /// <summary>
         /// Adds a package version to be used with the release
         /// </summary>
-        /// <param name="stepName">The name of the step or package</param>
+        /// <param name="stepNameOrPackageId">The name of the step or package</param>
         /// <param name="packageReferenceName">The named package, or null if this is the default (unnamed) package</param>
         /// <param name="packageVersion">The version of the package</param>
-        void Add(string stepName, string packageReferenceName, string packageVersion);
+        void Add(string stepNameOrPackageId, string packageReferenceName, string packageVersion);
+        
         /// <summary>
-        /// Adds a package version for the unamed package to be used with the release
+        /// Adds a package version for the unnamed package to be used with the release
         /// </summary>
-        /// <param name="stepName">The name of the step or package</param>
+        /// <param name="stepNameOrPackageId">The name of the step or package</param>
         /// <param name="packageVersion">The version of the package</param>
-        void Add(string stepName, string packageVersion);
+        void Add(string stepNameOrPackageId, string packageVersion);
+        
         void Default(string packageVersion);
+        
         /// <summary>
         /// Get the version of a previously defined package
         /// </summary>
@@ -26,6 +32,7 @@ namespace Octopus.Cli.Commands.Releases
         /// <param name="packageId">The package ID, used as a secondary check to stepName </param>
         /// <returns>The version assigned to the package</returns>
         string ResolveVersion(string stepName, string packageId, string packageReferenceName);
+        
         /// <summary>
         /// Get the version of a previously defined unnamed package (i.e. package reference null is null)
         /// </summary>


### PR DESCRIPTION
The command line currently interprets something like `StepA:1.0.0` to mean a package reference name of blank string, which means it will only match the default package and not any of the named package references. 

This is not at all intuitive when dealing with something like `PackageA:1.0.0`, which feels like "whichever step PackageA appears in, use version 1.0.0". The wildcard not also spanning package reference names then feels unexpected.

This PR changes the default behaviour to assume WildCard rather than "default package reference name".

Fixes OctopusDeploy/Issues#5821