### PR TITLE
Add parameter validation for --timeout and --keepalive

### DIFF
--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -62,6 +62,36 @@ namespace Octo.Tests.Commands
         }
 
         [Test]
+        [TestCase("100")]
+        [TestCase("00:15:00")]
+        public void ShouldSupportValidIntAndTimespanForTimeout(string input)
+        {
+            CommandLineArgs.Add("--timeout=" + input);
+            TestCommandExtensions.Execute(apiCommand, CommandLineArgs.ToArray());
+        }
+        
+        [Test]
+        public void ShouldThrowNiceExceptionForInvalidTimeout()
+        {
+            CommandLineArgs.Add("--timeout=fred");
+            Assert.Throws<CommandException>(() => TestCommandExtensions.Execute(apiCommand, CommandLineArgs.ToArray()));
+        }
+        
+        [Test]
+        public void ShouldSupportValidIntForKeepAlive()
+        {
+            CommandLineArgs.Add("--keepalive=10");
+            TestCommandExtensions.Execute(apiCommand, CommandLineArgs.ToArray());
+        }
+        
+        [Test]
+        public void ShouldThrowNiceExceptionForInvalidKeepalive()
+        {
+            CommandLineArgs.Add("--keepalive=fred");
+            Assert.Throws<CommandException>(() => TestCommandExtensions.Execute(apiCommand, CommandLineArgs.ToArray()));
+        }
+        
+        [Test]
         public Task ShouldNotThrowIfCustomOptionsAreAddedByCommand()
         {
             CommandLineArgs.Add("--pill=red");

--- a/source/Octo.Tests/Commands/ApiCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixture.cs
@@ -80,8 +80,10 @@ namespace Octo.Tests.Commands
         [Test]
         public void ShouldSupportValidIntForKeepAlive()
         {
+#if NETFRAMEWORK
             CommandLineArgs.Add("--keepalive=10");
             TestCommandExtensions.Execute(apiCommand, CommandLineArgs.ToArray());
+#endif
         }
         
         [Test]

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -68,13 +68,27 @@ namespace Octopus.Cli.Commands
             options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
             options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
             options.Add("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
-            options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v => clientOptions.Timeout = TimeSpan.FromSeconds(int.Parse(v)));
+            options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v =>
+            {
+                if (int.TryParse(v, out var parsedInt))
+                    clientOptions.Timeout = TimeSpan.FromSeconds(parsedInt);
+                else if (TimeSpan.TryParse(v, out var parsedTimeSpan))
+                    clientOptions.Timeout = parsedTimeSpan;
+                else
+                    throw new CommandException($"Unable to parse '{v}' as a timespan or an integer.");
+            });
             options.Add("proxy=", $"[Optional] The URL of the proxy to use, e.g., 'https://proxy.example.com'.", v => clientOptions.Proxy = v);
             options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
             options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
             options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);
 #if NETFRAMEWORK
-            options.Add("keepalive=", "[Optional] How frequently (in seconds) to send a TCP keepalive packet.", input => keepAlive = int.Parse(input) * 1000);
+            options.Add("keepalive=", "[Optional] How frequently (in seconds) to send a TCP keepalive packet.", input =>
+            {
+                if (int.TryParse(input, out var parsedInt))
+                    keepAlive = parsedInt * 1000;
+                else
+                    throw new CommandException($"Unable to parse '{input}' as an integer.");
+            });
 #endif
             options.AddLogLevelOptions();
         }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/OctopusCLI/issues/22

### No timeout param
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting
Octopus Deploy Command Line Tool, version 1.0.0
Detected automation environment: "NoneOrUnknown"
Space name unspecified, process will run in the default space context
Handshaking with Octopus Server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin
Pushing package: C:\temp\fakeservice.1.0.zip...
Requesting signature for delta compression from the server for upload of a package with id 'fakeservice' and version '1.0'
Calculating delta
The delta file (59 bytes) is 0.00% the size of the orginal file (1,575,824 bytes), uploading...
Delta transfer completed
Push successful
```

### invalid timeout param
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting --timeout fred
Unable to parse 'fred' as a timespan or an integer.
Exit code: -1
```

### Timeout as timespan
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting --timeout 00:15:00
Octopus Deploy Command Line Tool, version 1.0.0
Detected automation environment: "NoneOrUnknown"
Space name unspecified, process will run in the default space context
Handshaking with Octopus Server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin
Pushing package: C:\temp\fakeservice.1.0.zip...
Requesting signature for delta compression from the server for upload of a package with id 'fakeservice' and version '1.0'
Calculating delta
The delta file (59 bytes) is 0.00% the size of the orginal file (1,575,824 bytes), uploading...
Delta transfer completed
Push successful
```

### Timeout as int
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting --timeout 120
Octopus Deploy Command Line Tool, version 1.0.0
Detected automation environment: "NoneOrUnknown"
Space name unspecified, process will run in the default space context
Handshaking with Octopus Server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin
Pushing package: C:\temp\fakeservice.1.0.zip...
Requesting signature for delta compression from the server for upload of a package with id 'fakeservice' and version '1.0'
Calculating delta
The delta file (59 bytes) is 0.00% the size of the orginal file (1,575,824 bytes), uploading...
Delta transfer completed
Push successful
```

### invalid keepalive param
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting --keepalive fred
Unable to parse 'fred' as an integer.
Exit code: -1
```

### Keepalive as int
```
PS > .\Octo.exe push --server $server --apikey $apikey --package C:\temp\fakeservice.1.0.zip --overwrite-mode overwriteexisting --keepalive 30
Octopus Deploy Command Line Tool, version 1.0.0

Detected automation environment: "NoneOrUnknown"
Space name unspecified, process will run in the default space context
Handshaking with Octopus Server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin
Pushing package: C:\temp\fakeservice.1.0.zip...
Requesting signature for delta compression from the server for upload of a package with id 'fakeservice' and version '1.0'
Calculating delta
The delta file (59 bytes) is 0.00% the size of the orginal file (1,575,824 bytes), uploading...
Delta transfer completed
Push successful
```