### PR TITLE
With release creation, include the Release Log in output

### DIFF
--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio4" />
+    <PackageReference Include="Octopus.Client" Version="7.3.6-enh-release-creatio4" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="7.2.0" />
+    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio2" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio2" />
+    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio4" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -186,7 +186,7 @@ namespace Octopus.Cli.Commands.Releases
                 }
                 catch (OperationNotSupportedByOctopusServerException ex)
                 {
-                    commandOutputProvider.Warning(ex.Message);
+                    commandOutputProvider.Information(ex.Message);
                 }
                 catch (Exception ex)
                 {

--- a/source/Octopus.Cli/Diagnostics/LogExtensions.cs
+++ b/source/Octopus.Cli/Diagnostics/LogExtensions.cs
@@ -141,9 +141,9 @@ namespace Octopus.Cli.Diagnostics
             switch (logCategory)
             {
                 case LogCategory.Trace:
-                    return LogEventLevel.Debug;
-                case LogCategory.Verbose:
                     return LogEventLevel.Verbose;
+                case LogCategory.Verbose:
+                    return LogEventLevel.Debug;
                 case LogCategory.Info:
                 case LogCategory.Planned:
                 case LogCategory.Highlight:

--- a/source/Octopus.Cli/Diagnostics/LogExtensions.cs
+++ b/source/Octopus.Cli/Diagnostics/LogExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Octopus.Client.AutomationEnvironments;
 using Octopus.Client.Model;
 using Serilog;
+using Serilog.Events;
 
 namespace Octopus.Cli.Diagnostics
 {
@@ -132,6 +133,33 @@ namespace Octopus.Cli.Diagnostics
                 }
 
                 log.Information("##vso[task.addattachment type=Distributedtask.Core.Summary;name=Octopus Deploy;]{MarkdownFile:l}", markdownFile);
+            }
+        }
+
+        public static LogEventLevel ToLogEventLevel(this LogCategory logCategory)
+        {
+            switch (logCategory)
+            {
+                case LogCategory.Trace:
+                    return LogEventLevel.Debug;
+                case LogCategory.Verbose:
+                    return LogEventLevel.Verbose;
+                case LogCategory.Info:
+                case LogCategory.Planned:
+                case LogCategory.Highlight:
+                case LogCategory.Abandoned:
+                case LogCategory.Wait:
+                case LogCategory.Progress:
+                case LogCategory.Finished:
+                    return LogEventLevel.Information;
+                case LogCategory.Warning:
+                    return LogEventLevel.Warning;
+                case LogCategory.Error:
+                    return LogEventLevel.Error;
+                case LogCategory.Fatal:
+                    return LogEventLevel.Fatal;
+                default:
+                    return LogEventLevel.Information;
             }
         }
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio2" />
+    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio4" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio4" />
+    <PackageReference Include="Octopus.Client" Version="7.3.6-enh-release-creatio4" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="7.2.0" />
+    <PackageReference Include="Octopus.Client" Version="7.3.1-enh-release-creatio2" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />


### PR DESCRIPTION
After a release is created, the Release Log is fetched and its messages incorporated into the rest of the command output at the corresponding log levels.

Part of a solution to OctopusDeploy/Issues#5869.