### PR TITLE
Allow dotnet-octo to work when .NET Core 2.1 is not installed

### DIFF
--- a/source/Octopus.DotNet.Cli/runtimeconfig.template.json
+++ b/source/Octopus.DotNet.Cli/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://gist.githubusercontent.com/natemcmaster/0bdee16450f8ec1823f2c11af880ceeb/raw/runtimeconfig.template.schema.json",
+    // '2' allows for major-version roll-forward
+    "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
tldr; When installing dotnet-octo in a docker container with .net core > 2.1, dotnet-octo doesn't work. :(
runtimeconfig.template.json will add 
ollForwardOnNoCandidateFX:2 to the runtimeconfig.json. This will effectively allow the tool to work on .netcore 3.0

Test Notes

Create a dockerfile with the following:

```Dockerfile
FROM  mcr.microsoft.com/dotnet/core/sdk:3.0

COPY ./DotNetOctoTest/Octopus.DotNet.Cli.1.0.0.nupkg /build/

WORKDIR /build

RUN mkdir .tools && \
    dotnet tool install --version 1.0.0 --add-source . --tool-path .tools Octopus.DotNet.Cli

ENTRYPOINT [ "/build/.tools/dotnet-octo" ]
CMD [ "help" ]
```
1. `dotnet pack .\source\Octopus.DotNet.Cli\Octopus.DotNet.Cli.csproj -c Release -o .\DotNetOctoTest\`
1. `docker build -t dotnet-octo -f TestDotnetOcto.Dockerfile .`
1. `docker run --rm dotnet-octo`