### PR TITLE
Allow roll forward to newer major framework versions

### DIFF
--- a/source/Octo/runtimeconfig.template.json
+++ b/source/Octo/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+    "rollForward": "Major"
+}


### PR DESCRIPTION
# The enhancement

@jeremyabbott contributed a PR to enable compatibility with .NET Core Runtime 3. This is a good idea, but I noticed the option is deprecated. I think we'll proceed with the new option: `"rollForward": "Major"`

I've tested this on an Azure DevOps build pipeline with only .NET Core 3.0 installed.

## Links

The original PR: https://github.com/OctopusDeploy/OctopusCLI/pull/25