### PR TITLE
Update help for push-metadata to flag as deprecated.

### DIFF
--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -10,7 +10,7 @@ using Octopus.Client.Model.PackageMetadata;
 
 namespace Octopus.Cli.Commands.Package
 {
-    [Command("push-metadata", Description = "Pushes package metadata to Octopus Server.")]
+    [Command("push-metadata", Description = "Pushes package metadata to Octopus Server.  Deprecated. Please use the build-information command for Octopus Server 2019.10.0 and above.")]
     public class PushMetadataCommand : ApiCommand, ISupportFormattedOutput
     {
         private OctopusPackageMetadataMappedResource resultResource;


### PR DESCRIPTION
So that our docs get updated to highlight its out of date.