### PR TITLE
Launch Octo from absolute path

### DIFF
--- a/BuildAssets/Octo
+++ b/BuildAssets/Octo
@@ -5,7 +5,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   SOURCE="$(readlink "$SOURCE")"
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
-cd -P "$( dirname "$SOURCE" )"
+OCTO_PATH="$( dirname "$SOURCE")/Octo.Dll"
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582
-LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll "$@"
+LTTNG_UST_REGISTER_TIMEOUT=0 dotnet "$OCTO_PATH" "$@"


### PR DESCRIPTION
This prevents changing to the `Octo` path, which is a surprise when trying to do an operation like `Octo pack` and the `Octo` path is packed instead of the current path.