### PR TITLE
Multitarget octo & dotnet tool for continuity with past releases - portable zip targets 2.0 again

### DIFF
--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
-MAINTAINER robert.erez devops@octopus.com
 
 #alpine doesnt have curl installed
 #RUN apk add --no-cache curl

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,5 +1,4 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-nanoserver-1809
-MAINTAINER robert.erez devops@octopus.com
 ARG OCTO_TOOLS_VERSION=4.31.1
 
 LABEL maintainer="devops@octopus.com" \ 

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-nanoserver-1809
+FROM microsoft/dotnet:2.1-runtime-nanoserver-sac2016
 ARG OCTO_TOOLS_VERSION=4.31.1
 
 LABEL maintainer="devops@octopus.com" \ 

--- a/build.cake
+++ b/build.cake
@@ -128,7 +128,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp2.0",
+        Framework = "netcoreapp2.0" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")

--- a/build.cake
+++ b/build.cake
@@ -128,7 +128,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp3.1",
+        Framework = "netcoreapp2.0",
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     


### PR DESCRIPTION
# Background

Upgrading everything to 3.1 immediately was going to cause compatibility problems:
- The portable .NET Core Zip and `dotnet tool install Octopus.DotNet.Cli` would require .NET Core runtime 3.1 instead of 2.0, without sufficient warning
- OctoTFS would also fall victim to this
- The Windows nanoserver docker image currently depends on a `sac2016` base image that is no longer being shipped for new .NET Core versions, so would have needed rework

# Solution

This change multitargets the `octo` and `Octopus.DotNet.Cli` projects, so that:
- `octo` targets .NET Core 3.1 for the self-contained executables
- `octo` continues to target .NET Core 2.0 for the portable .NET Core zip
- `Octopus.DotNet.Cli` nuget package contains binaries for both 2.1 and 3.1, and the tool installer picks the right one
- Windows nanoserver docker image is back to using the original base image because the portable zip works with it again

Housekeeping:
- Retire deprecated `MAINTAINER` field; `LABEL maintainer` covers this