### PR TITLE
Fix up the executable name in the help

### DIFF
--- a/source/Octo.Tests/Commands/HelpCommandFixture.cs
+++ b/source/Octo.Tests/Commands/HelpCommandFixture.cs
@@ -61,7 +61,7 @@ namespace Octo.Tests.Commands
 
             output.ToString()
                 .Should()
-                .Contain("Usage: Octo.Tests speak [<options>]");
+                .MatchRegex(@"Usage: (octo|testhost) speak \[<options>\]");
         }
 
         [Test]

--- a/source/Octopus.Cli/Commands/CommandBase.cs
+++ b/source/Octopus.Cli/Commands/CommandBase.cs
@@ -44,7 +44,7 @@ namespace Octopus.Cli.Commands
         {
             var typeInfo = this.GetType().GetTypeInfo();
 
-            var executable = Path.GetFileNameWithoutExtension(typeInfo.Assembly.FullLocalPath());
+            var executable = AssemblyExtensions.GetExecutableName();
             var commandAttribute = typeInfo.GetCustomAttribute<CommandAttribute>();
             string commandName = string.Empty;
             if (commandAttribute == null)


### PR DESCRIPTION
Was showing as `Octopus.Cli`. Should show as `octo`