### PR TITLE
Include the help description in the help output

### DIFF
--- a/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
+++ b/source/Octo.Tests/Commands/ApiCommandFixtureBase.cs
@@ -5,6 +5,7 @@ using System.Text;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Cli.Repositories;
+using Octopus.Cli.Tests.Helpers;
 using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
@@ -43,8 +44,13 @@ namespace Octo.Tests.Commands
             Log = new LoggerConfiguration()
                 .WriteTo.TextWriter(new StringWriter(LogOutput), outputTemplate: "{Message}{NewLine}{Exception}", formatProvider: new StringFormatter(null))
                 .CreateLogger();
-           
-            RootResource rootDocument = Substitute.For<RootResource>();
+            
+            var consoleWriter = new ConsoleWriter();
+            consoleWriter.WriteEvent += (sender, args) => LogOutput.Append(args.Value);
+            consoleWriter.WriteLineEvent += (sender, args) => LogOutput.AppendLine(args.Value);
+            Console.SetOut(consoleWriter);
+
+            var rootDocument = Substitute.For<RootResource>();
             rootDocument.ApiVersion = "2.0";
             rootDocument.Version = "2.0";
             rootDocument.Links.Add("Tenants", "http://tenants.org");
@@ -75,8 +81,6 @@ namespace Octo.Tests.Commands
                 "--server=http://the-server",
                 "--apiKey=ABCDEF123456789"
             };
-
-
         }
 
         public StringBuilder LogOutput { get; set; }

--- a/source/Octo.Tests/Commands/DummyApiCommand.cs
+++ b/source/Octo.Tests/Commands/DummyApiCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Octopus.Cli.Commands;
+using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
 using Octopus.Client;
@@ -23,13 +24,15 @@ namespace Octo.Tests.Commands
         }
     }
 
+    [Command("dummy-command", Description = "this is the command's description")]
     public class DummyApiCommandWithFormattedOutputSupport : ApiCommand, ISupportFormattedOutput
     {
         public bool QueryCalled { get; set; }
         public bool PrintDefaultOutputCalled { get; set; }
         public bool PrintJsonOutputCalled { get; set; }
 
-        public DummyApiCommandWithFormattedOutputSupport(IOctopusClientFactory clientFactory, IOctopusAsyncRepositoryFactory repositoryFactory, IOctopusFileSystem fileSystem, ICommandOutputProvider commandOutputProvider) : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
+        public DummyApiCommandWithFormattedOutputSupport(IOctopusClientFactory clientFactory, IOctopusAsyncRepositoryFactory repositoryFactory, IOctopusFileSystem fileSystem, ICommandOutputProvider commandOutputProvider)
+            : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             
         }

--- a/source/Octo.Tests/Commands/SupportFormattedOutputFixture.cs
+++ b/source/Octo.Tests/Commands/SupportFormattedOutputFixture.cs
@@ -13,71 +13,73 @@ namespace Octo.Tests.Commands
         [Test]
         public void FormattedOutput_ShouldAddOutputOption()
         {
-            // arrange
-            StringWriter sw = new StringWriter();
-            DummyApiCommandWithFormattedOutputSupport command =
-                new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
+            var sw = new StringWriter();
+            var command =  new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
 
-            // act
             command.GetHelp(sw, new []{ "command" });
 
-            // assert
             sw.ToString().Should().ContainEquivalentOf("--output");
         }
 
         [Test]
         public async Task FormattedOutput_FormatSetToJson()
         {
-            // arrange
-            DummyApiCommandWithFormattedOutputSupport command =
+            var command =
                 new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
 
             CommandLineArgs.Add("--outputFormat=json");
 
-            // act
             await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
 
-            // assert
             command.PrintJsonOutputCalled.ShouldBeEquivalentTo(true);
         }
         
         [Test]
         public async Task FormattedOutput_FormatInvalid()
         {
-            // arrange
-            DummyApiCommandWithFormattedOutputSupport command =
-                new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
+            var command = new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
             CommandLineArgs.Add("--helpOutputFormat=blah");
 
-            // act
             await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
 
-            // assert
             command.PrintJsonOutputCalled.ShouldBeEquivalentTo(false);
             command.PrintDefaultOutputCalled.ShouldBeEquivalentTo(true);
         }
 
         [Test]
-        public async Task FormattedOutputHelp_ShouldBeWellFormed()
+        public async Task JsonFormattedOutputHelp_ShouldBeWellFormed()
         {
-            // arrange
-            DummyApiCommandWithFormattedOutputSupport command =
-                new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
+            var command = new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
 
             CommandLineArgs.Add("--helpOutputFormat=json");
             CommandLineArgs.Add("--help");
 
-            // act
             await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
 
-            // assert
-            var logoutput = LogOutput.ToString();
-            Console.WriteLine(logoutput);
-            JsonConvert.DeserializeObject(logoutput);
-            logoutput.Should().Contain("--helpOutputFormat=VALUE");
-            logoutput.Should().Contain("--help");
-
+            var logOutput = LogOutput.ToString();
+            Console.WriteLine(logOutput);
+            JsonConvert.DeserializeObject(logOutput);
+            logOutput.Should().Contain("--helpOutputFormat=VALUE");
+            logOutput.Should().Contain("--help");
+            logOutput.Should().Contain("dummy-command");
+            logOutput.Should().Contain("this is the command's description");
         }
+        
+        [Test]
+        public async Task PlainTextFormattedOutputHelp_ShouldBeWellFormed()
+        {
+            var command = new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
 
+            CommandLineArgs.Add("--help");
+
+            await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
+
+            var logOutput = LogOutput.ToString();
+            Console.WriteLine(logOutput);
+            logOutput.Should().Contain("--helpOutputFormat=VALUE");
+            logOutput.Should().Contain("--help");
+            logOutput.Should().Contain("dummy-command");
+            logOutput.Should().Contain("this is the command's description");
+        }
     }
 }

--- a/source/Octo.Tests/Helpers/ConsoleWriter.cs
+++ b/source/Octo.Tests/Helpers/ConsoleWriter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Octopus.Cli.Tests.Helpers
+{
+    //copied from https://stackoverflow.com/a/11911734/779192
+    public class ConsoleWriter : TextWriter
+    {
+        public class ConsoleWriterEventArgs : EventArgs
+        {
+            public string Value { get; private set; }
+            public ConsoleWriterEventArgs(string value)
+            {
+                Value = value;
+            }
+        }
+            
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(string value)
+        {
+            WriteEvent?.Invoke(this, new ConsoleWriterEventArgs(value));
+        }
+
+        public override void WriteLine(string value)
+        {
+            WriteLineEvent?.Invoke(this, new ConsoleWriterEventArgs(value));
+        }
+
+        public event EventHandler<ConsoleWriterEventArgs> WriteEvent;
+        public event EventHandler<ConsoleWriterEventArgs> WriteLineEvent;
+    }
+}

--- a/source/Octopus.Cli/Commands/CommandBase.cs
+++ b/source/Octopus.Cli/Commands/CommandBase.cs
@@ -46,7 +46,8 @@ namespace Octopus.Cli.Commands
 
             var executable = AssemblyExtensions.GetExecutableName();
             var commandAttribute = typeInfo.GetCustomAttribute<CommandAttribute>();
-            string commandName = string.Empty;
+            string commandName;
+            var description = string.Empty;
             if (commandAttribute == null)
             {
                 commandName = args.FirstOrDefault();
@@ -54,20 +55,21 @@ namespace Octopus.Cli.Commands
             else
             {
                 commandName = commandAttribute.Name;
+                description = commandAttribute.Description;
             }
 
             commandOutputProvider.PrintMessages = HelpOutputFormat == OutputFormat.Default;
             if (HelpOutputFormat  == OutputFormat.Json)
             {
-                PrintJsonHelpOutput(commandName);
+                PrintJsonHelpOutput(writer, commandName, description);
             }
             else
             {
-                PrintDefaultHelpOutput(writer, executable, commandName);
+                PrintDefaultHelpOutput(writer, executable, commandName, description);
             }
         }
 
-        protected void SetOutputFormat(string s)
+        private void SetOutputFormat(string s)
         {
             OutputFormat = ParseOutputFormat(s);
         }
@@ -83,17 +85,18 @@ namespace Octopus.Cli.Commands
             return Enum.TryParse(s, true, out outputFormat) ? outputFormat : OutputFormat.Default;
         }
 
-        private void PrintDefaultHelpOutput(TextWriter writer, string executable, string commandName)
+        private void PrintDefaultHelpOutput(TextWriter writer, string executable, string commandName, string description)
         {
-            commandOutputProvider.PrintCommandHelpHeader(executable, commandName, writer);
+            commandOutputProvider.PrintCommandHelpHeader(executable, commandName, description, writer);
             commandOutputProvider.PrintCommandOptions(Options, writer);
         }
 
-        private void PrintJsonHelpOutput(string commandName)
+        private void PrintJsonHelpOutput(TextWriter writer, string commandName, string description)
         {
             commandOutputProvider.Json(new
             {
                 Command = commandName,
+                Description = description,
                 Options = Options.OptionSets.OrderByDescending(x => x.Key).Select(g => new
                 {
                     @Group = g.Key,
@@ -106,7 +109,7 @@ namespace Octopus.Cli.Commands
                         p.Description
                     })
                 })
-            });
+            }, writer);
         }
     }
 }

--- a/source/Octopus.Cli/Util/CommandOutputProvider.cs
+++ b/source/Octopus.Cli/Util/CommandOutputProvider.cs
@@ -32,11 +32,13 @@ namespace Octopus.Cli.Util
             }
         }
        
-        public void PrintCommandHelpHeader(string executable, string commandName, TextWriter textWriter)
+        public void PrintCommandHelpHeader(string executable, string commandName, string description, TextWriter textWriter)
         {
             if (PrintMessages)
             {
                 Console.ResetColor();
+                textWriter.WriteLine(description);
+                textWriter.WriteLine();
                 textWriter.Write("Usage: ");
                 Console.ForegroundColor = ConsoleColor.White;
                 textWriter.WriteLine($"{executable} {commandName} [<options>]");
@@ -96,6 +98,11 @@ namespace Octopus.Cli.Util
         public void Json(object o)
         {
             logger.Information(Octopus.Client.Serialization.JsonSerialization.SerializeObject(o));
+        }
+        
+        public void Json(object o, TextWriter writer)
+        {
+            writer.WriteLine(Octopus.Client.Serialization.JsonSerialization.SerializeObject(o));
         }
 
         public void Warning(string s)

--- a/source/Octopus.Cli/Util/ICommandOutputProvider.cs
+++ b/source/Octopus.Cli/Util/ICommandOutputProvider.cs
@@ -12,7 +12,7 @@ namespace Octopus.Cli.Util
 
         void PrintHeader();
 
-        void PrintCommandHelpHeader(string executable, string commandName, TextWriter textWriter);
+        void PrintCommandHelpHeader(string executable, string commandName, string description, TextWriter textWriter);
 
         void PrintCommandOptions(Options options, TextWriter textWriter);
 
@@ -25,6 +25,7 @@ namespace Octopus.Cli.Util
         void Information(string template, params object[] propertyValues);
 
         void Json(object o);
+        void Json(object o, TextWriter writer);
         void Warning(string s);
         void Warning(string template, params object[] propertyValues);
         void Error(string template, params object[] propertyValues);


### PR DESCRIPTION
Adds the help description to the top of the `--help` output

(this was an old bit of code that I had around but never quite got around to finishing.)

### previous

```
PS> octo version --help
Usage: octo version [<options>]

Where [<options>] is any of:

Common options:

      --help                 [Optional] Print help for a command
      --helpOutputFormat=VALUE
                             [Optional] Output format for help, only valid
                             option is json
```

### new

```
PS> octo version --help
Output Octopus CLI version.

Usage: octo version [<options>]

Where [<options>] is any of:

Common options:

      --help                 [Optional] Print help for a command
      --helpOutputFormat=VALUE
                             [Optional] Output format for help, only valid
                             option is json
```

note the extra `Output Octopus CLI version.` at the top