### PR TITLE
Revert changes relating to lowercase, .NET Core 3.1, and self-contained

### DIFF
--- a/BuildAssets/Octo
+++ b/BuildAssets/Octo
@@ -5,7 +5,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   SOURCE="$(readlink "$SOURCE")"
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
-OCTO_PATH="$( dirname "$SOURCE")/octo.dll"
+OCTO_PATH="$( dirname "$SOURCE")/Octo.Dll"
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582
 LTTNG_UST_REGISTER_TIMEOUT=0 dotnet "$OCTO_PATH" "$@"

--- a/BuildAssets/Octo
+++ b/BuildAssets/Octo
@@ -5,7 +5,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   SOURCE="$(readlink "$SOURCE")"
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
-OCTO_PATH="$( dirname "$SOURCE")/Octo.Dll"
+cd -P "$( dirname "$SOURCE" )"
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582
-LTTNG_UST_REGISTER_TIMEOUT=0 dotnet "$OCTO_PATH" "$@"
+LTTNG_UST_REGISTER_TIMEOUT=0 dotnet Octo.dll "$@"

--- a/BuildAssets/Octo.cmd
+++ b/BuildAssets/Octo.cmd
@@ -1,0 +1,1 @@
+dotnet "%~dp0/Octo.dll" %*

--- a/BuildAssets/OctopusTools.nuspec
+++ b/BuildAssets/OctopusTools.nuspec
@@ -2,15 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd" xmlns:octopus="http://octopus.org">
   <metadata>
     <id>OctopusTools</id>
-    <title>Octopus CLI</title>
+    <title>Octo.exe</title>
     <version>$version$</version>
     <authors>Octopus Deploy</authors>
     <owners>Octopus Deploy</owners>
     <summary>Create, deploy and promote releases using Octopus Deploy.</summary>
     <description>
-      Octopus is a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks.
-
-      This package contains the Octopus CLI (octo), a tool to create and deploy releases, create and push packages, and manage environments with Octopus.
+      Octopus Deploy is an automated release management tool for modern developers and DevOps teams.
+	  
+	  This package contains Octo.exe, a command line tool for creating and deploying releases with Octopus Deploy.
     </description>
     <releaseNotes></releaseNotes>
     <language>en-US</language>

--- a/BuildAssets/octo.cmd
+++ b/BuildAssets/octo.cmd
@@ -1,1 +1,0 @@
-dotnet "%~dp0/octo.dll" %*

--- a/Dockerfiles/Readme.md
+++ b/Dockerfiles/Readme.md
@@ -1,5 +1,5 @@
 # octopusdeploy/octo
-A docker wrapped version of the popular Octopus CLI, [octo](https://octopus.com/docs/api-and-integration/octo.exe-command-line)
+A docker wrapped version of the popular [octo.exe](https://octopus.com/docs/api-and-integration/octo.exe-command-line) command line tool
 
 ## Platforms
 Images are currently available for
@@ -8,7 +8,7 @@ Images are currently available for
 
 
 ## Command Options
-Arguments passed to the container will be passed directly to the `octo` tool internally. For the full list of commands and parameters [read our docs](https://octopus.com/docs/api-and-integration/octo.exe-command-line).
+Arguments passed to the container will be passed directly to the `octo.exe` tool internally. For the full list of commands and parameters [read our docs](https://octopus.com/docs/api-and-integration/octo.exe-command-line).
 
 ### Example Usage
 #### Help

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
+MAINTAINER robert.erez devops@octopus.com
 
 #alpine doesnt have curl installed
 #RUN apk add --no-cache curl

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
+FROM microsoft/dotnet:2.1-runtime-alpine
 MAINTAINER robert.erez devops@octopus.com
 
 #alpine doesnt have curl installed

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -14,7 +14,7 @@ ENV LANG en_US.UTF-8
 # The dotnetcore bootstrapper doesnt work in alpine shell (built for bash)
 # This allows invoking octo if running interactive container
 RUN mkdir /octo &&\
-        echo "dotnet /octo/octo.dll \"\$@\"" > /octo/alpine &&\
+        echo "dotnet /octo/Octo.dll \"\$@\"" > /octo/alpine &&\
         ln /octo/alpine /usr/bin/octo &&\
         chmod +x /usr/bin/octo
         
@@ -31,4 +31,4 @@ RUN tar -zxvf /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz -C /octo &&\
 
 
 WORKDIR /src
-ENTRYPOINT ["dotnet", "/octo/octo.dll"]
+ENTRYPOINT ["dotnet", "/octo/Octo.dll"]

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,4 +1,5 @@
-FROM microsoft/dotnet:2.1-runtime-nanoserver-sac2016
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1-nanoserver-1809
+MAINTAINER robert.erez devops@octopus.com
 ARG OCTO_TOOLS_VERSION=4.31.1
 
 LABEL maintainer="devops@octopus.com" \ 

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-nanoserver-1809
+FROM microsoft/dotnet:2.1-runtime-nanoserver-sac2016
 MAINTAINER robert.erez devops@octopus.com
 ARG OCTO_TOOLS_VERSION=4.31.1
 

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -14,4 +14,4 @@ RUN Invoke-WebRequest $Env:OCTO_TOOLS_DOWNLOAD_URL -OutFile OctopusTools.zip; \
 	mkdir src |Out-Null
 
 WORKDIR /src
-ENTRYPOINT ["dotnet", "/octo/octo.dll"]
+ENTRYPOINT ["dotnet", "/octo/Octo.dll"]

--- a/build.cake
+++ b/build.cake
@@ -128,7 +128,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp2.0" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
+        Framework = "netcoreapp3.1",
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")

--- a/build.cake
+++ b/build.cake
@@ -128,7 +128,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp3.1",
+        Framework = "netcoreapp2.0",
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")
@@ -145,7 +145,7 @@ Task("DotnetPublish")
     {
         DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
         {
-            Framework = "netcoreapp3.1",
+            Framework = "netcoreapp2.0",
             Configuration = configuration,
             Runtime = rid,
             OutputDirectory = $"{octoPublishFolder}/{rid}",

--- a/build.cake
+++ b/build.cake
@@ -135,8 +135,8 @@ Task("DotnetPublish")
     });
     SignBinaries(portablePublishDir);
 
-    CopyFileToDirectory($"{assetDir}/octo", portablePublishDir);
-    CopyFileToDirectory($"{assetDir}/octo.cmd", portablePublishDir);
+    CopyFileToDirectory($"{assetDir}/Octo", portablePublishDir);
+    CopyFileToDirectory($"{assetDir}/Octo.cmd", portablePublishDir);
 
     var doc = new XmlDocument();
     doc.Load(@".\source\Octo\Octo.csproj");
@@ -167,8 +167,8 @@ Task("MergeOctoExe")
         var outputFolder = $"{octoPublishFolder}/netfx-merged";
         CreateDirectory(outputFolder);
         ILRepack(
-            $"{outputFolder}/octo.exe",
-            $"{inputFolder}/octo.exe",
+            $"{outputFolder}/Octo.exe",
+            $"{inputFolder}/Octo.exe",
             System.IO.Directory.EnumerateFiles(inputFolder, "*.dll")
 				.Union(System.IO.Directory.EnumerateFiles(inputFolder, "octodiff.exe"))
 				.Select(f => (FilePath) f),
@@ -273,9 +273,9 @@ private void SignBinaries(string path)
 {
     Information($"Signing binaries in {path}");
 	var files = GetFiles(path + "/**/Octopus.*.dll");
-    files.Add(GetFiles(path + "/**/octo.dll"));
-    files.Add(GetFiles(path + "/**/octo.exe"));
-    files.Add(GetFiles(path + "/**/octo"));
+    files.Add(GetFiles(path + "/**/Octo.dll"));
+    files.Add(GetFiles(path + "/**/Octo.exe"));
+    files.Add(GetFiles(path + "/**/Octo"));
     files.Add(GetFiles(path + "/**/dotnet-octo.dll"));
 
 	Sign(files, new SignToolSignSettings {

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 #tool "nuget:?package=ILRepack&version=2.0.13"
 #addin "nuget:?package=SharpCompress&version=0.12.4"
-#addin "nuget:?package=Cake.Incubator&version=5.1.0"
+#addin "nuget:?package=Cake.Incubator&version=4.0.0"
 
 using SharpCompress;
 using SharpCompress.Common;
@@ -149,16 +149,13 @@ Task("DotnetPublish")
             Configuration = configuration,
             Runtime = rid,
             OutputDirectory = $"{octoPublishFolder}/{rid}",
-			ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}"),
-            SelfContained = true,
-            PublishSingleFile = true
+			ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")
         });
-        if (!rid.StartsWith("linux-") && !rid.StartsWith("osx-")) {
-            // Sign binaries, except linux which are verified at download, and osx which are signed on a mac
-            SignBinaries($"{octoPublishFolder}/{rid}");
-        }
+        SignBinaries($"{octoPublishFolder}/{rid}");
     }
+
 });
+
 
 Task("MergeOctoExe")
     .IsDependentOn("DotnetPublish")
@@ -275,7 +272,6 @@ private void SignBinaries(string path)
 	var files = GetFiles(path + "/**/Octopus.*.dll");
     files.Add(GetFiles(path + "/**/Octo.dll"));
     files.Add(GetFiles(path + "/**/Octo.exe"));
-    files.Add(GetFiles(path + "/**/Octo"));
     files.Add(GetFiles(path + "/**/dotnet-octo.dll"));
 
 	Sign(files, new SignToolSignSettings {

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
-This repository contains the Octopus CLI (`octo`) for [Octopus][1], a user-friendly DevOps tool for developers that supports release management, deployment automation, and operations runbooks. You can use it to create and deploy releases, create and push packages, and manage environments.
+This repository contains the command line tool (`Octo.exe`) for [Octopus Deploy][1], an automated deployment server for professional .NET developers. You can use it to create and deploy releases, create and push packages, and manage environments.
 
-`octo` can be [downloaded from the Octopus downloads page][2].
+`Octo.exe` can be [downloaded from the Octopus downloads page][2].
 
 ## Documentation
-- [octo][3]
+- [Octo.exe][3]
 
 ## Issues
 Please see [Contributing](CONTRIBUTING.md)

--- a/source/Octo.Tests/Commands/HelpCommandFixture.cs
+++ b/source/Octo.Tests/Commands/HelpCommandFixture.cs
@@ -47,7 +47,7 @@ namespace Octo.Tests.Commands
 
             output.ToString()
                 .Should()
-                .MatchRegex(@"Usage: (octo|testhost) <command> \[<options>\]")
+                .Contain("Usage: octo <command> [<options>]")
                 .And.Contain("Where <command> is one of:")
                 .And.Contain("create-foo");
         }

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Octo.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);HAS_APP_CONTEXT</DefineConstants>
   </PropertyGroup>
 
@@ -47,7 +47,7 @@
   </ItemGroup>
 
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
-    <AssemblyName>octo</AssemblyName>
+    <AssemblyName>Octo</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>OctopusTools</PackageId>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -19,7 +19,7 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;linuxmint.17-x64;centos.7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>Octo</AssemblyName>
@@ -17,7 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;linuxmint.17-x64;centos.7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/source/Octopus.Cli/CliProgram.cs
+++ b/source/Octopus.Cli/CliProgram.cs
@@ -14,7 +14,6 @@ using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Exceptions;
 using Serilog;
-using AssemblyExtensions = Octopus.Cli.Util.AssemblyExtensions;
 
 namespace Octopus.Cli
 {
@@ -155,7 +154,7 @@ namespace Octopus.Cli
                 Log.Error(ex.Message);
                 if (LogExtensions.IsKnownEnvironment())
                 {
-                    Log.Error($"This error is most likely occurring while executing {AssemblyExtensions.GetExecutableName()} as part of an automated build process. The following doc is recommended to get some tips on how to troubleshoot this: https://g.octopushq.com/OctoexeTroubleshooting");
+                    Log.Error("This error is most likely occurring while executing Octo.exe as part of an automated build process. The following doc is recommended to get some tips on how to troubleshoot this: https://g.octopushq.com/OctoexeTroubleshooting");
                 }
                 return -1;
             }

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -188,7 +188,7 @@ namespace Octopus.Cli.Commands
             {
                 if (!serverHasSpaces)
                 {
-                    throw new CommandException($"The server {endpoint.OctopusServer} has no spaces. Try invoking {AssemblyExtensions.GetExecutableName()} without specifying the space name as an argument");
+                    throw new CommandException($"The server {endpoint.OctopusServer} has no spaces. Try invoking the Octo tool without specifying the space name as an argument");
                 }
 
                 var space = await client.ForSystem().Spaces.FindByNameOrIdOrFail(spaceNameOrId).ConfigureAwait(false);

--- a/source/Octopus.Cli/Commands/ExportCommand.cs
+++ b/source/Octopus.Cli/Commands/ExportCommand.cs
@@ -34,7 +34,7 @@ namespace Octopus.Cli.Commands
 
         protected override Task Execute()
         {
-            commandOutputProvider.Warning($"The {AssemblyExtensions.GetExecutableName()} import/export commands have been deprecated. See https://g.octopushq.com/DataMigration for alternative options.");
+            commandOutputProvider.Warning("The octo.exe import/export commands have been deprecated. See https://g.octopushq.com/DataMigration for alternative options.");
         
             if (string.IsNullOrWhiteSpace(Type)) throw new CommandException("Please specify the type to export using the parameter: --type=XYZ");
             if (string.IsNullOrWhiteSpace(FilePath)) throw new CommandException("Please specify the full path and name of the export file using the parameter: --filePath=XYZ");

--- a/source/Octopus.Cli/Commands/HelpCommand.cs
+++ b/source/Octopus.Cli/Commands/HelpCommand.cs
@@ -1,9 +1,12 @@
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Model;
 using Octopus.Cli.Util;
+using Serilog;
 
 namespace Octopus.Cli.Commands
 {
@@ -26,7 +29,7 @@ namespace Octopus.Cli.Commands
 
                 commandOutputProvider.PrintMessages = OutputFormat == OutputFormat.Default;
 
-                executable = AssemblyExtensions.GetExecutableName();
+                executable = "octo";
 
                 var commandName = commandLineArguments.FirstOrDefault();
 

--- a/source/Octopus.Cli/Commands/ImportCommand.cs
+++ b/source/Octopus.Cli/Commands/ImportCommand.cs
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Commands
 
         protected override async Task Execute()
         {
-            commandOutputProvider.Warning($"The {AssemblyExtensions.GetExecutableName()} import/export commands have been deprecated. See https://g.octopushq.com/DataMigration for alternative options.");
+            commandOutputProvider.Warning("The octo.exe import/export commands have been deprecated. See https://g.octopushq.com/DataMigration for alternative options.");
 
             if (string.IsNullOrWhiteSpace(Type)) throw new CommandException("Please specify the type of object to import using the parameter: --type=XYZ");
             if (string.IsNullOrWhiteSpace(FilePath)) throw new CommandException("Please specify the full path and name of the export file to import using the parameter: --filePath=XYZ");

--- a/source/Octopus.Cli/Commands/VersionCommand.cs
+++ b/source/Octopus.Cli/Commands/VersionCommand.cs
@@ -5,7 +5,7 @@ using Octopus.Cli.Util;
 
 namespace Octopus.Cli.Commands
 {
-    [Command("version", "v", "ver", Description = "Output Octopus CLI version.")]
+    [Command("version", "v", "ver", Description = "Output Octo command line tool version.")]
     public class VersionCommand : CommandBase, ICommand
     {
         public VersionCommand(ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)

--- a/source/Octopus.Cli/Util/AssemblyExtensions.cs
+++ b/source/Octopus.Cli/Util/AssemblyExtensions.cs
@@ -19,5 +19,10 @@ namespace Octopus.Cli.Util
         {
             return type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
+
+        public static string GetExecutableName()
+        {
+            return Assembly.GetEntryAssembly()?.GetName().Name ?? "octo";
+        }
     }
 }

--- a/source/Octopus.Cli/Util/AssemblyExtensions.cs
+++ b/source/Octopus.Cli/Util/AssemblyExtensions.cs
@@ -19,10 +19,5 @@ namespace Octopus.Cli.Util
         {
             return type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
         }
-
-        public static string GetExecutableName()
-        {
-            return Assembly.GetEntryAssembly()?.GetName().Name ?? "octo";
-        }
     }
 }

--- a/source/Octopus.Cli/Util/FeatureDetectionExtensions.cs
+++ b/source/Octopus.Cli/Util/FeatureDetectionExtensions.cs
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Util
 
         public static bool UsePostForChannelVersionRuleTest(this RootResource source)
         {
-            // Assume octo 3.4 should use the OctopusServer 3.4 POST, otherwise if we're certain this is an older Octopus Server use the GET method
+            // Assume octo.exe 3.4 should use the OctopusServer 3.4 POST, otherwise if we're certain this is an older Octopus Server use the GET method
             SemanticVersion octopusServerVersion;
             return source == null || !SemanticVersion.TryParse(source.Version, out octopusServerVersion) || octopusServerVersion >= new SemanticVersion("3.4");
         }

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.36.0" />
+    <package id="Cake" version="0.24.0" />
 </packages>


### PR DESCRIPTION
# Background

We have reclassified the impact of these changes as a major bump, so we want to revert them to finish the 6.17.x release series before applying them again.

# Change

This reverts changes relating to lowercase, .NET Core 3.1, and self-contained.