### PR TITLE
OctopusTools package: switch from netfx-merged to self-contained win-x64

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -213,12 +213,12 @@ Task("Zip")
 
 
 Task("PackOctopusToolsNuget")
-    .IsDependentOn("MergeOctoExe")
+    .IsDependentOn("DotnetPublish")
     .Does(() => {
         var nugetPackDir = $"{publishDir}/nuget";
         var nuspecFile = "OctopusTools.nuspec";
 
-        CopyDirectory($"{octoPublishFolder}/netfx-merged", nugetPackDir);
+        CopyDirectory($"{octoPublishFolder}/win-x64", nugetPackDir);
         CopyFileToDirectory($"{assetDir}/LICENSE.txt", nugetPackDir);
         CopyFileToDirectory($"{assetDir}/VERIFICATION.txt", nugetPackDir);
         CopyFileToDirectory($"{assetDir}/init.ps1", nugetPackDir);


### PR DESCRIPTION
# Background

The Chocolatey package, and nuget's OctousTools package, currently contain a .NET Framework Windows executable.

# Change

This uses the .NET Core 3.1 self-contained windows x64 executable in those packages instead.