### PR TITLE
Add capitalized Octo wrapper to tar.gz for linux & portable

### DIFF
--- a/BuildAssets/OctoWrapper.sh
+++ b/BuildAssets/OctoWrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo 'Note: The Octo command has been renamed to octo. Redirecting...' >&2
+echo 'Deprecated: The Octo command has been renamed to octo.' >&2
 "$(dirname "$0")/octo" "$@"

--- a/BuildAssets/OctoWrapper.sh
+++ b/BuildAssets/OctoWrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo 'Note: The Octo command has been renamed to octo. Redirecting...' >&2
+"$(dirname "$0")/octo" "$@"

--- a/BuildAssets/octo
+++ b/BuildAssets/octo
@@ -7,7 +7,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 OCTO_PATH="$( dirname "$SOURCE")/octo.dll"
 if [ "$(basename "$0")" == "Octo" ]; then
-  echo 'Note: The Octo command has been renamed to octo. Redirecting...' >&2
+  echo 'Deprecated: The Octo command has been renamed to octo..' >&2
 fi
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582

--- a/BuildAssets/octo
+++ b/BuildAssets/octo
@@ -6,6 +6,9 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 OCTO_PATH="$( dirname "$SOURCE")/octo.dll"
+if [ "$(basename "$0")" == "Octo" ]; then
+  echo 'Note: The Octo command has been renamed to octo. Redirecting...' >&2
+fi
 # LTTNG_UST_REGISTER_TIMEOUT=0 is there to work around a bug in docker that causes an assertion violation in dotnet on first launch
 # See https://github.com/dotnet/cli/issues/1582
 LTTNG_UST_REGISTER_TIMEOUT=0 dotnet "$OCTO_PATH" "$@"

--- a/build.cake
+++ b/build.cake
@@ -297,11 +297,14 @@ private void TarGzip(string path, string outputFile, bool insertUpperCaseOctoWra
     {
         using (var tar = WriterFactory.Open(tarMemStream, ArchiveType.Tar, CompressionType.None, true))
         {
+            // If using a capitalized wrapper, insert it first so it wouldn't overwrite the main payload on a case-insensitive system.
             if (insertUpperCaseOctoWrapper) {
                 tar.Write("Octo", $"{assetDir}/OctoWrapper.sh");
             } else if (insertUpperCaseDotNetWrapper) {
                 tar.Write("Octo", $"{assetDir}/octo");
             }
+
+            // Add the remaining files
             tar.WriteAll(path, "*", SearchOption.AllDirectories);
         }
 

--- a/build.cake
+++ b/build.cake
@@ -206,7 +206,9 @@ Task("Zip")
                     Zip(dir, outFile + ".zip");
 
                 if(!dirName.Contains("win"))
-                    TarGzip(dir, outFile);
+                    TarGzip(dir, outFile,
+                        insertUpperCaseOctoWrapper: dirName.Contains("linux"),
+                        insertUpperCaseDotNetWrapper: dirName == "portable");
             }
         }
     });
@@ -287,7 +289,7 @@ private void SignBinaries(string path)
 }
 
 
-private void TarGzip(string path, string outputFile)
+private void TarGzip(string path, string outputFile, bool insertUpperCaseOctoWrapper = false, bool insertUpperCaseDotNetWrapper = false)
 {
     var outFile = $"{outputFile}.tar.gz";
     Information("Creating TGZ file {0} from {1}", outFile, path);
@@ -295,6 +297,11 @@ private void TarGzip(string path, string outputFile)
     {
         using (var tar = WriterFactory.Open(tarMemStream, ArchiveType.Tar, CompressionType.None, true))
         {
+            if (insertUpperCaseOctoWrapper) {
+                tar.Write("Octo", $"{assetDir}/OctoWrapper.sh");
+            } else if (insertUpperCaseDotNetWrapper) {
+                tar.Write("Octo", $"{assetDir}/octo");
+            }
             tar.WriteAll(path, "*", SearchOption.AllDirectories);
         }
 

--- a/build.cake
+++ b/build.cake
@@ -207,8 +207,8 @@ Task("Zip")
 
                 if(!dirName.Contains("win"))
                     TarGzip(dir, outFile,
-                        insertUpperCaseOctoWrapper: dirName.Contains("linux"),
-                        insertUpperCaseDotNetWrapper: dirName == "portable");
+                        insertCapitalizedOctoWrapper: dirName.Contains("linux"),
+                        insertCapitalizedDotNetWrapper: dirName == "portable");
             }
         }
     });
@@ -289,7 +289,7 @@ private void SignBinaries(string path)
 }
 
 
-private void TarGzip(string path, string outputFile, bool insertUpperCaseOctoWrapper = false, bool insertUpperCaseDotNetWrapper = false)
+private void TarGzip(string path, string outputFile, bool insertCapitalizedOctoWrapper = false, bool insertCapitalizedDotNetWrapper = false)
 {
     var outFile = $"{outputFile}.tar.gz";
     Information("Creating TGZ file {0} from {1}", outFile, path);
@@ -298,9 +298,9 @@ private void TarGzip(string path, string outputFile, bool insertUpperCaseOctoWra
         using (var tar = WriterFactory.Open(tarMemStream, ArchiveType.Tar, CompressionType.None, true))
         {
             // If using a capitalized wrapper, insert it first so it wouldn't overwrite the main payload on a case-insensitive system.
-            if (insertUpperCaseOctoWrapper) {
+            if (insertCapitalizedOctoWrapper) {
                 tar.Write("Octo", $"{assetDir}/OctoWrapper.sh");
-            } else if (insertUpperCaseDotNetWrapper) {
+            } else if (insertCapitalizedDotNetWrapper) {
                 tar.Write("Octo", $"{assetDir}/octo");
             }
 


### PR DESCRIPTION
# Background

Before 7.0.0, the `octo` command was capitalized: `Octo`.

The change doesn't affect invocations in Windows or macOS, but it does affect linux.

# Change

This change adds capitalized `Octo` wrappers to the Linux and portable tarballs. We haven't put these in the Windows / macOS / portable `.zip` archives, because having `Octo` and `octo` in the same archive has confusing effects on case-insensitive systems like Windows and macOS.