### PR TITLE
Build docker images during build phase, not publish phase

### DIFF
--- a/Dockerfiles/Readme.md
+++ b/Dockerfiles/Readme.md
@@ -4,7 +4,7 @@ A docker wrapped version of the popular Octopus CLI, [octo](https://octopus.com/
 ## Platforms
 Images are currently available for
 - [linux/amd64](alpine/Dockerfile) - based on alpine
-- [windows/amd64](alpine/Dockerfile) - based on nanoserver
+- [windows/amd64](nanoserver/Dockerfile) - based on windows nanoserver
 
 
 ## Command Options

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -20,7 +20,7 @@ LABEL maintainer="devops@octopus.com"
 LABEL octopus.dockerfile.version="1.0"
 LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
-COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.portable.tar.gz ./tmp/OctopusTools.portable.tar.gz
+COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz ./tmp/OctopusTools.portable.tar.gz
 
 RUN tar -zxvf /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz -C /octo &&\
 	rm /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,8 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
 
-#alpine doesnt have curl installed
-#RUN apk add --no-cache curl
-
 # Alpine base image does not have ICU libraries available
 # https://github.com/dotnet/corefx/blob/master/Documentation/architecture/globalization-invariant-mode.md
 RUN apk add --no-cache icu-libs
@@ -19,15 +16,14 @@ RUN mkdir /octo &&\
         
 ARG OCTO_TOOLS_VERSION=4.31.1
 
-LABEL maintainer="devops@octopus.com" \
-        octopus.dockerfile.version="1.0" \
-        octopus.tools.version=$OCTO_TOOLS_VERSION
+LABEL maintainer="devops@octopus.com"
+LABEL octopus.dockerfile.version="1.0"
+LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
+COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.portable.tar.gz ./tmp/OctopusTools.portable.tar.gz
 
-ADD https://download.octopusdeploy.com/octopus-tools/$OCTO_TOOLS_VERSION/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz /tmp
 RUN tar -zxvf /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz -C /octo &&\
 	rm /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz
-
 
 WORKDIR /src
 ENTRYPOINT ["dotnet", "/octo/octo.dll"]

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -22,8 +22,8 @@ LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
 COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz ./tmp/OctopusTools.portable.tar.gz
 
-RUN tar -zxvf /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz -C /octo &&\
-	rm /tmp/OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz
+RUN tar -zxvf /tmp/OctopusTools.portable.tar.gz -C /octo &&\
+	rm /tmp/OctopusTools.portable.tar.gz
 
 WORKDIR /src
 ENTRYPOINT ["dotnet", "/octo/octo.dll"]

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,15 +1,14 @@
 FROM microsoft/dotnet:2.1-runtime-nanoserver-sac2016
 ARG OCTO_TOOLS_VERSION=4.31.1
 
-LABEL maintainer="devops@octopus.com" \ 
-	octopus.dockerfile.version="1.0" \
-	octopus.tools.version=$OCTO_TOOLS_VERSION 
+LABEL maintainer="devops@octopus.com" 
+LABEL octopus.dockerfile.version="1.0"
+LABEL octopus.tools.version=$OCTO_TOOLS_VERSION 
 
-ENV OCTO_TOOLS_DOWNLOAD_URL https://download.octopusdeploy.com/octopus-tools/$OCTO_TOOLS_VERSION/OctopusTools.$OCTO_TOOLS_VERSION.portable.zip
+COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.zip ./octo/OctopusTools.zip
 
-RUN Invoke-WebRequest $Env:OCTO_TOOLS_DOWNLOAD_URL -OutFile OctopusTools.zip; \
-	Expand-Archive OctopusTools.zip -DestinationPath octo; \
-	Remove-Item -Force OctopusTools.zip; \
+RUN Expand-Archive ./octo/OctopusTools.zip -DestinationPath octo; \
+	Remove-Item -Force ./octo/OctopusTools.zip; \
 	mkdir src |Out-Null
 
 WORKDIR /src

--- a/build.cake
+++ b/build.cake
@@ -38,7 +38,6 @@ var dotNetOctoCliFolder = "./source/Octopus.DotNet.Cli";
 var dotNetOctoPublishFolder = $"{publishDir}/dotnetocto";
 var dotNetOctoMergedFolder =  $"{publishDir}/dotnetocto-Merged";
 
-GitVersion gitVersionInfo;
 string nugetVersion;
 
 
@@ -47,17 +46,26 @@ string nugetVersion;
 ///////////////////////////////////////////////////////////////////////////////
 Setup(context =>
 {
-     gitVersionInfo = GitVersion(new GitVersionSettings {
-        OutputType = GitVersionOutput.Json
-    });
-    nugetVersion = gitVersionInfo.NuGetVersion;
+    var fromEnv = Context.EnvironmentVariable("GitVersion.NuGetVersion");
+    
+    if (string.IsNullOrEmpty(fromEnv))
+    { 
+        var gitVersionInfo = GitVersion(new GitVersionSettings {
+            OutputType = GitVersionOutput.Json
+        });
+        nugetVersion = gitVersionInfo.NuGetVersion;
+        Information("Building OctopusCli v{0}", nugetVersion);
+        Information("Informational Version {0}", gitVersionInfo.InformationalVersion);
+        Verbose("GitVersion:\n{0}", gitVersionInfo.Dump());
+    }
+    else
+    {
+        nugetVersion = fromEnv;
+        Information("Building OctopusCli v{0}", nugetVersion);
+    }
 
     if(BuildSystem.IsRunningOnTeamCity)
         BuildSystem.TeamCity.SetBuildNumber(nugetVersion);
-
-    Information("Building OctopusCli v{0}", nugetVersion);
-    Information("Informational Version {0}", gitVersionInfo.InformationalVersion);
-    Verbose("GitVersion:\n{0}", gitVersionInfo.Dump());
 });
 
 Teardown(context =>

--- a/build.cake
+++ b/build.cake
@@ -46,7 +46,7 @@ string nugetVersion;
 ///////////////////////////////////////////////////////////////////////////////
 Setup(context =>
 {
-    var fromEnv = Context.EnvironmentVariable("GitVersion.NuGetVersion");
+    var fromEnv = context.EnvironmentVariable("GitVersion.NuGetVersion");
     
     if (string.IsNullOrEmpty(fromEnv))
     { 
@@ -279,12 +279,18 @@ Task("CopyToLocalPackages")
 Task("AssertDotNetOctoNugetExists")
     .Does(() =>
 {
-    var file = artifactsDir + $"/OctopusTools.{nugetVersion}.portable.zip";
-    if (!FileExists(file))
-        throw new Exception($"This build requires the portable zip at {file}. This either means the tools package wasn't build successfully, or the build artifacts were not put into the expected location.");
-    file = artifactsDir + $"/OctopusTools.{nugetVersion}.portable.tar.gz";
-    if (!FileExists(file))
-        throw new Exception($"This build requires the portable tar.gz file at {file}. This either means the tools package wasn't build successfully, or the build artifacts were not put into the expected location.");
+    if (IsRunningOnWindows())
+    {    
+        var file = artifactsDir + $"/OctopusTools.{nugetVersion}.portable.zip";
+        if (!FileExists(file))
+            throw new Exception($"This build requires the portable zip at {file}. This either means the tools package wasn't build successfully, or the build artifacts were not put into the expected location.");
+    } 
+    else
+    {
+        var file = artifactsDir + $"/OctopusTools.{nugetVersion}.portable.tar.gz";
+        if (!FileExists(file))
+            throw new Exception($"This build requires the portable tar.gz file at {file}. This either means the tools package wasn't build successfully, or the build artifacts were not put into the expected location.");
+    }
 });
 
 Task("BuildDockerImage")

--- a/source/OctopusCli.sln
+++ b/source/OctopusCli.sln
@@ -21,6 +21,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.DotNet.Cli", "Octop
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octopus.Cli", "Octopus.Cli\Octopus.Cli.csproj", "{627462FB-2E70-4F9C-ACC9-8CF84BF6C196}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{994AA337-0E3B-44C3-83F8-0E6C5D3AA007}"
+ProjectSection(SolutionItems) = preProject
+	..\Dockerfiles\Readme.md = ..\Dockerfiles\Readme.md
+EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Alpine", "Alpine", "{32A3C564-207A-43DB-9588-27AFAF846C1A}"
+ProjectSection(SolutionItems) = preProject
+	..\Dockerfiles\alpine\Dockerfile = ..\Dockerfiles\alpine\Dockerfile
+EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NanoServer", "NanoServer", "{0E7214DA-B46B-4C56-A535-B5341080295E}"
+ProjectSection(SolutionItems) = preProject
+	..\Dockerfiles\nanoserver\Dockerfile = ..\Dockerfiles\nanoserver\Dockerfile
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -83,5 +98,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FD0E320F-79AC-4489-9508-C62497C629D3}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{32A3C564-207A-43DB-9588-27AFAF846C1A} = {994AA337-0E3B-44C3-83F8-0E6C5D3AA007}
+		{0E7214DA-B46B-4C56-A535-B5341080295E} = {994AA337-0E3B-44C3-83F8-0E6C5D3AA007}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
So that we can:
* find issues earlier
* (eventually) run tests when we build the container
* have a quicker publish
* stop deploy.octopushq.com doing build stuff
