### PR TITLE
Linux packages: add dependencies, executable permission, symlink

### DIFF
--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -40,12 +40,12 @@ fpm --version "$VERSION" \
   --vendor 'Octopus Deploy' \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
-  # Causes problems in centos:7 # --depends 'lttng-ust' \
   --depends 'libcurl' \
   --depends 'openssl-libs' \
   --depends 'krb5-libs' \
   --depends 'zlib' \
   --depends 'libicu' \
   "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli"
+# Omitted from rpm depends due to problems in centos:7... --depends 'lttng-ust'
 
 mv -f *.{deb,rpm} $ARTIFACTS

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -11,7 +11,7 @@ test -d tmp_usr_bin && rmdir tmp_usr_bin
 mkdir tmp_usr_bin && ln -s /opt/octopus/octopuscli/octo tmp_usr_bin/octo || exit 1
 
 # Create packages
-fpm --version $VERSION \
+fpm --version "$VERSION" \
   --name octopuscli \
   --input-type dir \
   --output-type deb \
@@ -26,10 +26,10 @@ fpm --version $VERSION \
   --depends 'libkrb5-3' \
   --depends 'zlib1g' \
   --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63' \
-  $OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli \
+  "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli" \
   tmp_usr_bin/=/usr/bin/
 
-fpm --version $VERSION \
+fpm --version "$VERSION" \
   --name octopuscli \
   --input-type dir \
   --output-type rpm \
@@ -37,6 +37,6 @@ fpm --version $VERSION \
   --vendor 'Octopus Deploy' \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
-  $OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli
+  "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli"
 
 mv -f *.{deb,rpm} $ARTIFACTS

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -45,7 +45,8 @@ fpm --version "$VERSION" \
   --depends 'krb5-libs' \
   --depends 'zlib' \
   --depends 'libicu' \
-  "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli"
+  "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli" \
+  tmp_usr_bin/=/usr/bin/
 # Omitted from rpm depends due to problems in centos:7... --depends 'lttng-ust'
 
 mv -f *.{deb,rpm} $ARTIFACTS

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -13,6 +13,9 @@ mkdir tmp_usr_bin && ln -s /opt/octopus/octopuscli/octo tmp_usr_bin/octo || exit
 # Set permissions
 chmod 755 "$OCTOPUSCLI_BINARIES/octo"
 
+# Exclude Octo legacy wrapper from distribution
+rm -f "$OCTOPUSCLI_BINARIES/Octo"
+
 # Create packages
 fpm --version "$VERSION" \
   --name octopuscli \

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
 # Remove existing packages, fpm doesnt like to overwrite
-rm *.{deb,rpm}
+rm -f *.{deb,rpm}
 
+# Remove build files
+rm -f tmp_usr_bin/octo
+test -d tmp_usr_bin && rmdir tmp_usr_bin
+
+# Create executable symlink to include in package
+mkdir tmp_usr_bin && ln -s /opt/octopus/octopuscli/octo tmp_usr_bin/octo || exit 1
+
+# Create packages
 fpm --version $VERSION \
   --name octopuscli \
   --input-type dir \
@@ -12,7 +20,14 @@ fpm --version $VERSION \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
   --deb-no-default-config-files \
-  $OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli
+  --depends 'liblttng-ust0' \
+  --depends 'libcurl3 | libcurl4' \
+  --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1' \
+  --depends 'libkrb5-3' \
+  --depends 'zlib1g' \
+  --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63' \
+  $OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli \
+  tmp_usr_bin/=/usr/bin/
 
 fpm --version $VERSION \
   --name octopuscli \

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -10,6 +10,9 @@ test -d tmp_usr_bin && rmdir tmp_usr_bin
 # Create executable symlink to include in package
 mkdir tmp_usr_bin && ln -s /opt/octopus/octopuscli/octo tmp_usr_bin/octo || exit 1
 
+# Set permissions
+chmod 755 "$OCTOPUSCLI_BINARIES/octo"
+
 # Create packages
 fpm --version "$VERSION" \
   --name octopuscli \

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -47,6 +47,7 @@ fpm --version "$VERSION" \
   --depends 'libicu' \
   "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli" \
   tmp_usr_bin/=/usr/bin/
-# Omitted from rpm depends due to problems in centos:7... --depends 'lttng-ust'
+# Note: Microsoft recommends dep 'lttng-ust' but it seems to be unavailable in CentOS 7, so we're omitting it for now.
+# As it's related to tracing, hopefully it will not be required for normal usage.
 
 mv -f *.{deb,rpm} $ARTIFACTS

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -40,6 +40,12 @@ fpm --version "$VERSION" \
   --vendor 'Octopus Deploy' \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
+  # Causes problems in centos:7 # --depends 'lttng-ust' \
+  --depends 'libcurl' \
+  --depends 'openssl-libs' \
+  --depends 'krb5-libs' \
+  --depends 'zlib' \
+  --depends 'libicu' \
   "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli"
 
 mv -f *.{deb,rpm} $ARTIFACTS


### PR DESCRIPTION
This change adds to the `.deb` and `.rpm` packages:
- Declares the dependencies listed [by Microsoft](https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?tabs=netcore31&pivots=os-linux#supported-operating-systems), adjusted to suit:
  - the last ~5 years of Debian & Ubuntu
  - the latest Linux Mint
  - CentOS 7-8
  - Fedora latest
- Add executable permission, which was in our dependency `.tar.gz`, but TeamCity didn't seem to be preserving when it unzipped
- Add a symlink to `octo` in `/usr/bin/` so that it will be on the `$PATH`.

Basic smoke tests (for now checking only exit code of `octo version`) for 4 distros are [on TeamCity](https://build.octopushq.com/viewType.html?buildTypeId=OctopusDeploy_OctopusCLI_TestLinuxPackages&branch_OctopusDeploy_OctopusCLI=enh-pkg-symlink-deps&tab=buildTypeStatusDiv) using these docker tags:
```
debian:stable-slim
ubuntu:latest
centos:latest
fedora:latest
```

I think the following would also work:
```
debian:oldstable-slim
ubuntu:rolling
centos:7
debian:oldoldstable-slim
ubuntu:xenial
linuxmintd/mint19.3-amd64
```