### PR TITLE
Test deb/rpm packages and publish them to apt/yum repos

### DIFF
--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -8,26 +8,26 @@
 #export GPG_PASSPHRASE=$(get_octopusvariable "Publish.APT.GPG.PassPhrase")
 
 echo "Importing private key"
-echo "$GPG_PRIVATEKEY" | gpg1 --batch --import || exit 1
-curl -s "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key" | gpg1 --no-default-keyring --keyring trustedkeys.gpg --import || exit 1
+echo "$GPG_PRIVATEKEY" | gpg1 --batch --import || exit
+curl -s "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key" | gpg1 --no-default-keyring --keyring trustedkeys.gpg --import || exit
 
 echo "Configuring S3 bucket"
 #aws s3 mb "s3://$S3_PUBLISH_ENDPOINT" || exit 1
 #aws s3api wait bucket-exists --bucket "$S3_PUBLISH_ENDPOINT" || exit 1
 #aws s3 sync ./apt-content "s3://$S3_PUBLISH_ENDPOINT" --acl public-read || exit 1
-aptly config show | jq '.S3PublishEndpoints[env.S3_PUBLISH_ENDPOINT] = {"region": "us-east-1", "bucket": env.S3_PUBLISH_ENDPOINT, "acl": "public-read"}' > ~/.aptly.conf.new || exit 1
-mv ~/.aptly.conf.new ~/.aptly.conf || exit 1
+aptly config show | jq '.S3PublishEndpoints[env.S3_PUBLISH_ENDPOINT] = {"region": "us-east-1", "bucket": env.S3_PUBLISH_ENDPOINT, "acl": "public-read"}' > ~/.aptly.conf.new || exit
+mv ~/.aptly.conf.new ~/.aptly.conf || exit
 
 echo "Creating APT repo"
-aptly repo create -distribution=stretch -component=main octopus || exit 1
+aptly repo create -distribution=stretch -component=main octopus || exit
 
 echo "Importing from existing APT repo"
-aptly mirror create octopus-mirror "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/" stretch || exit 1
-aptly mirror update octopus-mirror || exit 1
-aptly repo import octopus-mirror octopus '$Version' || exit 1
+aptly mirror create octopus-mirror "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/" stretch || exit
+aptly mirror update octopus-mirror || exit
+aptly repo import octopus-mirror octopus '$Version' || exit
 
 echo "Adding new packages"
-aptly repo add octopus ./OctopusTools.Packages.linux-x64 || exit 1
-aptly repo show -with-packages octopus || exit 1
+aptly repo add octopus ./OctopusTools.Packages.linux-x64 || exit
+aptly repo show -with-packages octopus || exit
 
-aptly publish repo -batch -passphrase "$GPG_PASSPHRASE" octopus s3:$S3_PUBLISH_ENDPOINT: || exit 1
+aptly publish repo -batch -passphrase "$GPG_PASSPHRASE" octopus "s3:$S3_PUBLISH_ENDPOINT:" || exit

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -1,8 +1,11 @@
-export GPG_PASSPHRASE=$(get_octopusvariable "Publish.APT.GPG.PassPhrase")
-export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
-export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
-export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.APT.S3.TargetBucket")
-GPG_PRIVATEKEY=$(get_octopusvariable "Publish.APT.GPG.PrivateKey")
+#!/bin/bash
+
+# Required env vars:
+#export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
+#export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
+#export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.APT.S3.TargetBucket")
+#export GPG_PRIVATEKEY=$(get_octopusvariable "Publish.APT.GPG.PrivateKey")
+#export GPG_PASSPHRASE=$(get_octopusvariable "Publish.APT.GPG.PassPhrase")
 
 echo "Importing private key"
 echo "$GPG_PRIVATEKEY" | gpg1 --batch --import || exit 1

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -15,7 +15,7 @@ echo "Configuring S3 bucket"
 #aws s3 mb "s3://$S3_PUBLISH_ENDPOINT" || exit 1
 #aws s3api wait bucket-exists --bucket "$S3_PUBLISH_ENDPOINT" || exit 1
 #aws s3 sync ./apt-content "s3://$S3_PUBLISH_ENDPOINT" --acl public-read || exit 1
-aptly config show | jq '.S3PublishEndpoints[env.S3_PUBLISH_ENDPOINT] = {"region": "us-east-1", "bucket": env.S3_PUBLISH_ENDPOINT, "acl": "public-read"}' > ~/.aptly.conf.new 2>&1 || exit
+aptly config show 2>/dev/null | jq '.S3PublishEndpoints[env.S3_PUBLISH_ENDPOINT] = {"region": "us-east-1", "bucket": env.S3_PUBLISH_ENDPOINT, "acl": "public-read"}' > ~/.aptly.conf.new || exit
 mv ~/.aptly.conf.new ~/.aptly.conf || exit
 
 echo "Creating APT repo"

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -1,0 +1,30 @@
+export GPG_PASSPHRASE=$(get_octopusvariable "Publish.APT.GPG.PassPhrase")
+export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
+export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
+export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.APT.S3.TargetBucket")
+GPG_PRIVATEKEY=$(get_octopusvariable "Publish.APT.GPG.PrivateKey")
+
+echo "Importing private key"
+echo "$GPG_PRIVATEKEY" | gpg1 --batch --import || exit 1
+curl -s "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key" | gpg1 --no-default-keyring --keyring trustedkeys.gpg --import || exit 1
+
+echo "Configuring S3 bucket"
+#aws s3 mb "s3://$S3_PUBLISH_ENDPOINT" || exit 1
+#aws s3api wait bucket-exists --bucket "$S3_PUBLISH_ENDPOINT" || exit 1
+#aws s3 sync ./apt-content "s3://$S3_PUBLISH_ENDPOINT" --acl public-read || exit 1
+aptly config show | jq '.S3PublishEndpoints[env.S3_PUBLISH_ENDPOINT] = {"region": "us-east-1", "bucket": env.S3_PUBLISH_ENDPOINT, "acl": "public-read"}' > ~/.aptly.conf.new || exit 1
+mv ~/.aptly.conf.new ~/.aptly.conf || exit 1
+
+echo "Creating APT repo"
+aptly repo create -distribution=stretch -component=main octopus || exit 1
+
+echo "Importing from existing APT repo"
+aptly mirror create octopus-mirror "https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/" stretch || exit 1
+aptly mirror update octopus-mirror || exit 1
+aptly repo import octopus-mirror octopus '$Version' || exit 1
+
+echo "Adding new packages"
+aptly repo add octopus ./OctopusTools.Packages.linux-x64 || exit 1
+aptly repo show -with-packages octopus || exit 1
+
+aptly publish repo -batch -passphrase "$GPG_PASSPHRASE" octopus s3:$S3_PUBLISH_ENDPOINT: || echo ERROR

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -30,4 +30,4 @@ echo "Adding new packages"
 aptly repo add octopus ./OctopusTools.Packages.linux-x64 || exit 1
 aptly repo show -with-packages octopus || exit 1
 
-aptly publish repo -batch -passphrase "$GPG_PASSPHRASE" octopus s3:$S3_PUBLISH_ENDPOINT: || echo ERROR
+aptly publish repo -batch -passphrase "$GPG_PASSPHRASE" octopus s3:$S3_PUBLISH_ENDPOINT: || exit 1

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -22,6 +22,14 @@ echo "Configuring S3 bucket"
 #aws s3 mb "s3://${S3_PUBLISH_ENDPOINT}" || exit 1
 #aws s3api wait bucket-exists --bucket ${S3_PUBLISH_ENDPOINT} || exit 1
 #aws s3 sync ./rpm-content "s3://${S3_PUBLISH_ENDPOINT}" --acl public-read || exit 1
+echo -e "[octopuscli]
+name=Octopus CLI
+baseurl=https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/\$basearch/
+enabled=1
+gpgkey=https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key
+gpgcheck=0
+" > octopuscli.repo
+aws s3 cp octopuscli.repo "s3://${S3_PUBLISH_ENDPOINT}/octopuscli.repo" --acl public-read || exit 1
 
 TARGET_DIR="/tmp/$S3_PUBLISH_ENDPOINT"
 

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#Usage: ./publish-rpm.sh -s artifacts -t octopus-rpm-repo
+#artifacts: this is the directory containing the rpm file(s)
+
+# Publishes built RPMs to an s3-backed RPM repo.
+export AWS_ACCESS_KEY_ID=$(get_octopusvariable "Publish.RPM.S3.AccessKeyId")
+export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "Publish.RPM.S3.SecretAccessKey")
+
+set -e
+if [ ! -z "${DEBUG}" ]; then
+  set -x
+fi
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SRC_BASE="${SCRIPT_DIR}/../.."
+
+DEPENDENCIES=("aws" "createrepo")
+SOURCE_DIR=""
+TARGET_BUCKET=""
+
+for dep in "${DEPENDENCIES[@]}"
+do
+  if [ ! $(which ${dep}) ]; then
+      echo "${dep} must be available."
+      exit 1
+  fi
+done
+
+while getopts "s:t:" opt; do
+  case $opt in
+    s) SOURCE_DIR=$OPTARG ;;
+    t) TARGET_BUCKET=$OPTARG ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "${SOURCE_DIR}" ]; then
+  echo "Source directory must be specified."
+  exit 1
+fi
+
+if [ -z "${TARGET_BUCKET}" ]; then
+  echo "Target bucket must be specified."
+  exit 1
+fi
+
+aws s3 mb "s3://${TARGET_BUCKET}"
+aws s3api wait bucket-exists --bucket ${TARGET_BUCKET}
+aws s3 sync ./rpm-content "s3://${TARGET_BUCKET}" --acl public-read
+
+TARGET_DIR="/tmp/${TARGET_BUCKET}"
+
+# make sure we're operating on the latest data in the target bucket
+mkdir -p $TARGET_DIR
+aws s3 sync "s3://${TARGET_BUCKET}" $TARGET_DIR
+
+# copy the RPM in and update the repo
+mkdir -pv $TARGET_DIR/x86_64/
+cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/x86_64/
+UPDATE=""
+if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
+  UPDATE="--update "
+fi
+for a in $TARGET_DIR/x86_64 ; do createrepo -v $UPDATE --deltas $a/ ; done
+
+# sync the repo state back to s3
+aws s3 sync $TARGET_DIR s3://$TARGET_BUCKET --acl public-read

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
 
-#Usage: ./publish-rpm.sh -s artifacts -t octopus-rpm-repo
-#artifacts: this is the directory containing the rpm file(s)
+# Required env vars:
+#export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
+#export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
+#export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.APT.S3.TargetBucket")
 
-# Publishes built RPMs to an s3-backed RPM repo.
-export AWS_ACCESS_KEY_ID=$(get_octopusvariable "Publish.RPM.S3.AccessKeyId")
-export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "Publish.RPM.S3.SecretAccessKey")
-
-set -e
 if [ ! -z "${DEBUG}" ]; then
   set -x
 fi
 
-SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-SRC_BASE="${SCRIPT_DIR}/../.."
-
 DEPENDENCIES=("aws" "createrepo")
-SOURCE_DIR=""
-TARGET_BUCKET=""
-
 for dep in "${DEPENDENCIES[@]}"
 do
   if [ ! $(which ${dep}) ]; then
@@ -27,45 +18,28 @@ do
   fi
 done
 
-while getopts "s:t:" opt; do
-  case $opt in
-    s) SOURCE_DIR=$OPTARG ;;
-    t) TARGET_BUCKET=$OPTARG ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
-      ;;
-  esac
-done
+echo "Configuring S3 bucket"
+#aws s3 mb "s3://${S3_PUBLISH_ENDPOINT}"|| echo ERROR
+#aws s3api wait bucket-exists --bucket ${S3_PUBLISH_ENDPOINT}|| echo ERROR
+#aws s3 sync ./rpm-content "s3://${S3_PUBLISH_ENDPOINT}" --acl public-read|| echo ERROR
 
-if [ -z "${SOURCE_DIR}" ]; then
-  echo "Source directory must be specified."
-  exit 1
-fi
-
-if [ -z "${TARGET_BUCKET}" ]; then
-  echo "Target bucket must be specified."
-  exit 1
-fi
-
-aws s3 mb "s3://${TARGET_BUCKET}"
-aws s3api wait bucket-exists --bucket ${TARGET_BUCKET}
-aws s3 sync ./rpm-content "s3://${TARGET_BUCKET}" --acl public-read
-
-TARGET_DIR="/tmp/${TARGET_BUCKET}"
+TARGET_DIR="/tmp/$S3_PUBLISH_ENDPOINT"
 
 # make sure we're operating on the latest data in the target bucket
-mkdir -p $TARGET_DIR
-aws s3 sync "s3://${TARGET_BUCKET}" $TARGET_DIR
+rm -rf "$TARGET_DIR"|| exit 1
+mkdir -p "$TARGET_DIR"|| exit 1
+aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR"|| exit 1
 
 # copy the RPM in and update the repo
-mkdir -pv $TARGET_DIR/x86_64/
-cp -rv $SOURCE_DIR/*.rpm $TARGET_DIR/x86_64/
+mkdir -pv "$TARGET_DIR/x86_64/"|| exit 1
+cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/"|| exit 1
 UPDATE=""
 if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
   UPDATE="--update "
 fi
-for a in $TARGET_DIR/x86_64 ; do createrepo -v $UPDATE --deltas $a/ ; done
+for a in "$TARGET_DIR/x86_64"; do
+  createrepo -v $UPDATE --deltas "$a/"|| exit 1
+done
 
 # sync the repo state back to s3
-aws s3 sync $TARGET_DIR s3://$TARGET_BUCKET --acl public-read
+aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete|| exit 1

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -19,27 +19,27 @@ do
 done
 
 echo "Configuring S3 bucket"
-#aws s3 mb "s3://${S3_PUBLISH_ENDPOINT}"|| echo ERROR
-#aws s3api wait bucket-exists --bucket ${S3_PUBLISH_ENDPOINT}|| echo ERROR
-#aws s3 sync ./rpm-content "s3://${S3_PUBLISH_ENDPOINT}" --acl public-read|| echo ERROR
+#aws s3 mb "s3://${S3_PUBLISH_ENDPOINT}" || exit 1
+#aws s3api wait bucket-exists --bucket ${S3_PUBLISH_ENDPOINT} || exit 1
+#aws s3 sync ./rpm-content "s3://${S3_PUBLISH_ENDPOINT}" --acl public-read || exit 1
 
 TARGET_DIR="/tmp/$S3_PUBLISH_ENDPOINT"
 
 # make sure we're operating on the latest data in the target bucket
-rm -rf "$TARGET_DIR"|| exit 1
-mkdir -p "$TARGET_DIR"|| exit 1
-aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR"|| exit 1
+rm -rf "$TARGET_DIR" || exit 1
+mkdir -p "$TARGET_DIR" || exit 1
+aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR" || exit 1
 
 # copy the RPM in and update the repo
-mkdir -pv "$TARGET_DIR/x86_64/"|| exit 1
-cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/"|| exit 1
+mkdir -pv "$TARGET_DIR/x86_64/" || exit 1
+cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/" || exit 1
 UPDATE=""
 if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
   UPDATE="--update "
 fi
 for a in "$TARGET_DIR/x86_64"; do
-  createrepo -v $UPDATE --deltas "$a/"|| exit 1
+  createrepo -v $UPDATE --deltas "$a/" || exit 1
 done
 
 # sync the repo state back to s3
-aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete|| exit 1
+aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete || exit 1

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -29,25 +29,25 @@ enabled=1
 gpgkey=https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key
 gpgcheck=0
 " > octopuscli.repo
-aws s3 cp octopuscli.repo "s3://${S3_PUBLISH_ENDPOINT}/octopuscli.repo" --acl public-read || exit 1
+aws s3 cp octopuscli.repo "s3://${S3_PUBLISH_ENDPOINT}/octopuscli.repo" --acl public-read || exit
 
 TARGET_DIR="/tmp/$S3_PUBLISH_ENDPOINT"
 
 # make sure we're operating on the latest data in the target bucket
-rm -rf "$TARGET_DIR" || exit 1
-mkdir -p "$TARGET_DIR" || exit 1
-aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR" || exit 1
+rm -rf "$TARGET_DIR" || exit
+mkdir -p "$TARGET_DIR" || exit
+aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR" || exit
 
 # copy the RPM in and update the repo
-mkdir -pv "$TARGET_DIR/x86_64/" || exit 1
-cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/" || exit 1
+mkdir -pv "$TARGET_DIR/x86_64/" || exit
+cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/" || exit
 UPDATE=""
 if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
   UPDATE="--update "
 fi
 for a in "$TARGET_DIR/x86_64"; do
-  createrepo -v $UPDATE --deltas "$a/" || exit 1
+  createrepo -v $UPDATE --deltas "$a/" || exit
 done
 
 # sync the repo state back to s3
-aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete || exit 1
+aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete || exit

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -3,7 +3,7 @@
 # Required env vars:
 #export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
 #export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
-#export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.APT.S3.TargetBucket")
+#export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.RPM.S3.TargetBucket")
 
 if [ ! -z "${DEBUG}" ]; then
   set -x

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script requires environment variables to run:
+#   S3_PUBLISH_ENDPOINT, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
+
+# Configure apt
+export DEBIAN_FRONTEND=noninteractive
+apt-get update --quiet 2 || exit
+apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
+apt-get install --no-install-recommends --yes gnupg curl software-properties-common >/dev/null || exit
+apt-key adv --fetch-keys "http://$S3_PUBLISH_ENDPOINT/public.key" || exit
+add-apt-repository "deb http://$S3_PUBLISH_ENDPOINT/ stretch main" || exit
+apt-get update --quiet 2 || exit
+
+# Install
+apt-get install --no-install-recommends --yes tentacle octopuscli >/dev/null || exit
+
+# Test
+echo "== Testing Tentacle =="
+/opt/octopus/tentacle/Tentacle version || exit
+echo
+echo "== Testing Octopus CLI =="
+octo version || exit
+apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
+OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
+echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -8,7 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update --quiet 2 || exit
 apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
 apt-get install --no-install-recommends --yes gnupg curl software-properties-common >/dev/null || exit
-apt-key adv --fetch-keys "http://$S3_PUBLISH_ENDPOINT/public.key" || exit
+apt-key adv --fetch-keys "http://$S3_PUBLISH_ENDPOINT/public.key" 2>&1 || exit
 add-apt-repository "deb http://$S3_PUBLISH_ENDPOINT/ stretch main" || exit
 apt-get update --quiet 2 || exit
 

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -8,8 +8,8 @@ curl -s "http://$S3_PUBLISH_ENDPOINT/tentacle.repo" -o /etc/yum.repos.d/tentacle
 curl -s "http://$S3_PUBLISH_ENDPOINT/octopuscli.repo" -o /etc/yum.repos.d/octopuscli.repo || exit
 
 # Install
-yum --quiet --assumeyes install tentacle || exit
-yum --quiet --assumeyes install octopuscli || exit
+yum --quiet --assumeyes install tentacle 2>&1 || exit
+yum --quiet --assumeyes install octopuscli 2>&1 || exit
 
 # Test
 echo "== Testing Tentacle =="

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script requires environment variables to run:
+#   S3_PUBLISH_ENDPOINT, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
+
+# Configure yum
+curl -s "http://$S3_PUBLISH_ENDPOINT/tentacle.repo" -o /etc/yum.repos.d/tentacle.repo || exit
+curl -s "http://$S3_PUBLISH_ENDPOINT/octopuscli.repo" -o /etc/yum.repos.d/octopuscli.repo || exit
+
+# Install
+yum --quiet --assumeyes install tentacle || exit
+yum --quiet --assumeyes install octopuscli || exit
+
+# Test
+echo "== Testing Tentacle =="
+/opt/octopus/tentacle/Tentacle version || exit
+echo
+echo "== Testing Octopus CLI =="
+octo version || exit
+OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
+echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script requires environment variables to run:
-#   OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_EXPECT_ENV
+#   OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
 # You must also supply either:
 #   TEST_QUICK (to skip some distributions)
 # or
@@ -20,7 +20,7 @@ TEST_DEB_SH='
   # Test octo
   octo version || exit
   apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
-  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
   echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
 '
 
@@ -31,7 +31,7 @@ TEST_RPM_SH='
 
   # Test octo
   octo version || exit
-  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
   echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
 '
 
@@ -44,14 +44,14 @@ TEST_RHEL_SH='
 
   # Test octo
   octo version || exit
-  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
   echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
 '
 
 test_in_docker () {
   echo "== Testing $1 =="
   docker pull "$1" >/dev/null || exit
-  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_EXPECT_ENV \
+  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
     --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit
 }
 

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -26,8 +26,7 @@ TEST_DEB_SH='
 
 TEST_RPM_SH='
   # Install octo
-  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1 | \
-    { grep -v "NOKEY$\|^Importing GPG\|^ Userid \|^ Fingerprint\|^ From"; exit 0; } || exit
+  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1 || exit
 
   # Test octo
   octo version || exit

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# This script requires environment variables to run:
+#   OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_EXPECT_ENV
+# You must also supply either:
+#   TEST_QUICK (to skip some distributions)
+# or
+#   REDHAT_SUBSCRIPTION_USERNAME, REDHAT_SUBSCRIPTION_PASSWORD (to support RHEL tests)
+
+TEST_DEB_SH='
+  # Configure apt
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update --quiet 2 || exit
+  apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
+
+  # Install octo
+  dpkg -i /pkgs/octopuscli*.deb >/dev/null 2>&1 # Silenced and expected to fail
+  apt-get --no-install-recommends --yes --fix-broken install >/dev/null 2>&1 || exit
+
+  # Test octo
+  octo version || exit
+  apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
+  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
+'
+
+TEST_RPM_SH='
+  # Install octo
+  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1 | \
+    { grep -v "NOKEY$\|^Importing GPG\|^ Userid \|^ Fingerprint\|^ From"; exit 0; } || exit
+
+  # Test octo
+  octo version || exit
+  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
+'
+
+TEST_RHEL_SH='
+  # Install octo
+  subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
+    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1
+  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm >/dev/null 2>&1
+  subscription-manager unsubscribe --all >/dev/null 2>&1
+
+  # Test octo
+  octo version || exit
+  OCTO_RESULT="$(octo list-environments --space=Integrations)" || { echo "$OCTO_RESULT"; exit 1; }
+  echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
+'
+
+test_in_docker () {
+  echo "== Testing $1 =="
+  docker pull "$1" >/dev/null || exit
+  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_EXPECT_ENV \
+    --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit
+}
+
+test_in_docker debian:stable-slim "$TEST_DEB_SH"
+test_in_docker ubuntu:latest "$TEST_DEB_SH"
+test_in_docker centos:latest "$TEST_RPM_SH"
+if [ -n "$TEST_QUICK" ]; then
+  echo "TEST_QUICK is enabled. Skipping the remaining distros."
+  exit 0
+fi
+test_in_docker fedora:latest "$TEST_RPM_SH"
+test_in_docker debian:oldstable-slim "$TEST_DEB_SH"
+test_in_docker ubuntu:rolling "$TEST_DEB_SH"
+test_in_docker centos:7 "$TEST_RPM_SH"
+test_in_docker debian:oldoldstable-slim "$TEST_DEB_SH"
+test_in_docker ubuntu:xenial "$TEST_DEB_SH"
+test_in_docker linuxmintd/mint19.3-amd64 "$TEST_DEB_SH"
+test_in_docker roboxes/rhel8 "$TEST_RHEL_SH"
+test_in_docker roboxes/rhel7 "$TEST_RHEL_SH"

--- a/build.cake
+++ b/build.cake
@@ -365,6 +365,8 @@ Task("CreateLinuxPackages")
     CreateDirectory($"{artifactsDir}/linuxpackages");
     MoveFiles(GetFiles($"{artifactsDir}/*.deb"), $"{artifactsDir}/linuxpackages");
     MoveFiles(GetFiles($"{artifactsDir}/*.rpm"), $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/publish-apt.sh", $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/publish-rpm.sh", $"{artifactsDir}/linuxpackages");
     TarGzip($"{artifactsDir}/linuxpackages", $"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}");
     var buildSystem = BuildSystemAliases.BuildSystem(Context);
     buildSystem.TeamCity.PublishArtifacts($"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}.tar.gz");

--- a/build.cake
+++ b/build.cake
@@ -368,6 +368,8 @@ Task("CreateLinuxPackages")
     CopyFileToDirectory($"{assetDir}/test-linux-packages.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/publish-apt.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/publish-rpm.sh", $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/test-apt.sh", $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/test-rpm.sh", $"{artifactsDir}/linuxpackages");
     TarGzip($"{artifactsDir}/linuxpackages", $"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}");
     var buildSystem = BuildSystemAliases.BuildSystem(Context);
     buildSystem.TeamCity.PublishArtifacts($"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}.tar.gz");

--- a/build.cake
+++ b/build.cake
@@ -365,6 +365,7 @@ Task("CreateLinuxPackages")
     CreateDirectory($"{artifactsDir}/linuxpackages");
     MoveFiles(GetFiles($"{artifactsDir}/*.deb"), $"{artifactsDir}/linuxpackages");
     MoveFiles(GetFiles($"{artifactsDir}/*.rpm"), $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/test-linux-packages.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/publish-apt.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/publish-rpm.sh", $"{artifactsDir}/linuxpackages");
     TarGzip($"{artifactsDir}/linuxpackages", $"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}");


### PR DESCRIPTION
This adds scripts to the archive with our linux packages that are used in the build and deploy:

- `test-linux-packages.sh` tests the `deb` and `rpm` packages in a variety of dockerized distros, to ensure `octo version` and `octo list-environments` work
- `publish-apt.sh` - creates a local repo based on our S3 repo, publishes our `deb`, pushes it back
- `publish-rpm.sh` - syncs the S3 repo to local, publishes our `rpm`, syncs back to S3
- `test-apt.sh` - tests the `apt` repo to ensure `octo version` and `octo list-environments` work
- `test-rpm.sh` - tests the `rpm` repo with yum to ensure `octo version` and `octo list-environments` work

Please review the contents of the scripts.