### PR TITLE
Support netcore 2.1, 2.2, 3.0 and 3.1 for dotnet tool

### DIFF
--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- 
+    We include all possible targets here so that no matter what framework version 
+    the user has installed, there is an appropriate build in the tools package
+    -->
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>


### PR DESCRIPTION
We thought we'd fixed this in https://github.com/OctopusDeploy/OctopusCLI/pull/25, but it didn't have the desired outcome.

While we are now encouraging customers to use platform native executables (available from the [downloads page](https://octopus.com/downloads/octopuscli)), this fixes it so that it works again.

Fixes https://github.com/OctopusDeploy/OctopusCLI/issues/28