### PR TITLE
Allow substitution of dependencies available in OpenSUSE

### DIFF
--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -43,9 +43,9 @@ fpm --version "$VERSION" \
   --vendor 'Octopus Deploy' \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
-  --depends 'libcurl' \
+  --depends '( libcurl or libcurl4 )' \
   --depends 'openssl-libs' \
-  --depends 'krb5-libs' \
+  --depends '( krb5-libs or krb5 )' \
   --depends 'zlib' \
   --depends 'libicu' \
   "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli" \

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -44,7 +44,7 @@ fpm --version "$VERSION" \
   --url 'https://octopus.com/' \
   --description 'Command line tool for Octopus Deploy' \
   --depends '( libcurl or libcurl4 )' \
-  --depends 'openssl-libs' \
+  --depends '( openssl-libs or libopenssl1_0_0 )' \
   --depends '( krb5-libs or krb5 )' \
   --depends 'zlib' \
   --depends 'libicu' \


### PR DESCRIPTION
# Background

In OpenSUSE, `libcurl` or `krb5-libs` have different names.

# Change

This change allows either dependency.