### PR TITLE
Fix up --ignoreSslErrors on linux

### DIFF
--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -17,7 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -17,8 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/source/Octopus.Cli/CliProgram.cs
+++ b/source/Octopus.Cli/CliProgram.cs
@@ -22,11 +22,10 @@ namespace Octopus.Cli
     {
         public int Execute(string[] args)
         {
-#if !HTTP_CLIENT_SUPPORTS_SSL_OPTIONS
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
                                                    | SecurityProtocolType.Tls11
                                                    | SecurityProtocolType.Tls12;
-#endif
+
             ConfigureLogger();
             return Run(args);
         }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -17,6 +17,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
We had all the code, but the compile time constant was in the wrong project.
This also needed us to upgrade past netcoreapp2.0.

Fixes https://github.com/OctopusDeploy/Issues/issues/4948
Fixes https://github.com/OctopusDeploy/Issues/issues/5906