### PR TITLE
Assemble apt & yum feeds in Artifactory before pushing to S3

### DIFF
--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which fpm >/dev/null || {
+  echo 'This script requires fpm and related tools, found in the container "octopusdeploy/bionic-fpm".' >&2
+  exit 1
+}
 if [[ -z "$VERSION" ]]; then
   echo 'This script requires the environment variable VERSION - the version being packaged.' >&2
   exit 1

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-if [[ -z "$VERSION" || -z "$OCTOPUSCLI_BINARIES" || -z "$ARTIFACTS" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  VERSION, OCTOPUSCLI_BINARIES, ARTIFACTS' >&2
+if [[ -z "$VERSION" ]]; then
+  echo 'This script requires the environment variable VERSION - the version being packaged.' >&2
+  exit 1
+fi
+if [[ -z "$OCTOPUSCLI_BINARIES" ]]; then
+  echo 'This script requires the environment variable OCTOPUSCLI_BINARIES - the path containing octo and related files.' >&2
+  exit 1
+fi
+if [[ -z "$OUT_PATH" ]]; then
+  echo 'This script requires the environment variable OUT_PATH - the path where packages should be written.' >&2
   exit 1
 fi
 
@@ -63,4 +70,4 @@ fpm --version "$VERSION" \
 # Note: Microsoft recommends dep 'lttng-ust' but it seems to be unavailable in CentOS 7, so we're omitting it for now.
 # As it's related to tracing, hopefully it will not be required for normal usage.
 
-mv -f *.{deb,rpm} $ARTIFACTS || exit
+mv -f *.{deb,rpm} "$OUT_PATH" || exit

--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Package files from OCTOPUSCLI_BINARIES, with executable permission and a /usr/bin symlink, into .deb and .rpm packages in OUT_PATH.
 
 which fpm >/dev/null || {
   echo 'This script requires fpm and related tools, found in the container "octopusdeploy/bionic-fpm".' >&2

--- a/BuildAssets/repos/README.md
+++ b/BuildAssets/repos/README.md
@@ -1,0 +1,47 @@
+# README
+
+# JFrog Artifactory Initial Setup
+
+*TODO: Automate this. It might be more appropriate as a runbook than part of package deployment, because (1) it belongs equally to Tentacle and Octopus CLI, (2) we'd usually want to bootstrap some initial packages, (3) it requires administrative permissions.*
+
+- Admin: General Security Configuration
+  - First remove anonymous from permissions & groups
+  - [x] Allow Anonymous Access
+  - [x] Hide Existence of Unauthorized Resources
+  - Allow Basic Read of Build Related Info
+        [ ] Apply on Anonymous Access
+- Admin: Repositories: Local: New
+  - Type: debian
+  - Key: apt-prerelease
+- Admin: Repositories: Local: New
+  - Type: debian
+  - Key: apt
+- Admin: Repositories: Local: New
+  - Type: rpm
+  - Key: rpm-prerelease
+  - [ ] Auto Calculate RPM Metadata
+  - [x] Enable file list indexing
+  - RPM Metadata Folder Depth: 1
+- Admin: Repositories: Local: New
+  - Type: rpm
+  - Key: rpm
+  - [ ] Auto Calculate RPM Metadata
+  - [x] Enable file list indexing
+  - RPM Metadata Folder Depth: 1
+- Admin: Signing Keys
+  - Added public/private/passphrase
+- Admin: Users: New
+  - User Name: linux-package-uploader
+  - Email Address: devops@octopus.com
+  - Set password
+  - Remove from groups
+- Admin: Permissions: Add
+  - Name: linux-package-uploader
+  - Repos: apt-prerelease, apt, rpm-prerelease, rpm
+  - Users: linux-package-uploader
+  - Actions: Repository up to Manage
+- Admin: Permissions: Add
+  - Name: linux-package-downloader
+  - Repos: apt-prerelease, apt, rpm-prerelease, rpm
+  - Users: anonymous
+  - Actions: Read

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -31,7 +31,7 @@ fi
 CURL_UPL_OPTS=(--silent --show-error --fail --user "$PUBLISH_ARTIFACTORY_USERNAME:$PUBLISH_ARTIFACTORY_PASSWORD")
 
 echo "Uploading package to Artifactory"
-PKG=$(ls -1 *.deb | head -n1)
+PKG=$(set -o pipefail; ls -1 *.deb | head -n1) || exit
 PKGBN=$(basename "$PKG")
 DISTS=(oldoldstable oldstable stable jessie stretch buster trusty xenial bionic cosmic disco eoan)
 DISTS=$(printf ";deb.distribution=%s" "${DISTS[@]}")
@@ -59,5 +59,7 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
+set -o pipefail
 curl --silent --show-error --fail --location https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit
+set +o pipefail

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Publish the first .deb in the working directory to an Artifactory apt repository, then sync the repository to S3.
 
 which curl rclone >/dev/null || {
   echo 'This script requires curl and rclone, found in the container "octopusdeploy/publish-linux".' >&2

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -3,7 +3,8 @@
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" \
    || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
   echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, PUBLISH_ARTIFACTORY_USERNAME, PUBLISH_ARTIFACTORY_PASSWORD, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY'
+  PUBLISH_LINUX_EXTERNAL, PUBLISH_ARTIFACTORY_USERNAME, PUBLISH_ARTIFACTORY_PASSWORD, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY' >&2
+  exit 1
 fi
 
 if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
@@ -15,7 +16,7 @@ else
   BUCKET='prerelease.apt.octopus.com'
   ORIGIN="http://$BUCKET"
 fi
-CURL_UPL_OPTS=(--silent --fail --user "$PUBLISH_ARTIFACTORY_USERNAME:$PUBLISH_ARTIFACTORY_PASSWORD")
+CURL_UPL_OPTS=(--silent --show-error --fail --user "$PUBLISH_ARTIFACTORY_USERNAME:$PUBLISH_ARTIFACTORY_PASSWORD")
 
 echo "Uploading package to Artifactory"
 PKG=$(ls -1 *.deb | head -n1)
@@ -36,15 +37,15 @@ echo "Preparing sync to S3"
 RCLONE_OPTS=(--config=/dev/null --verbose --s3-provider=AWS --s3-env-auth=true --s3-region=us-east-1 --s3-acl=public-read)
 RCLONE_SYNC_OPTS=(:http: ":s3:$BUCKET" --http-url="https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY" "${RCLONE_OPTS[@]}" \
   --fast-list --update --use-server-modtime)
-rclone sync "${RCLONE_SYNC_OPTS[@]}" --dry-run --include=*.deb --max-delete=0 \
-  || { echo 'Package deletion predicted. Aborting sync to S3 for manual investigation.'; exit 1; }
+rclone sync "${RCLONE_SYNC_OPTS[@]}" --dry-run --include=*.deb --max-delete=0 2>&1 \
+  || { echo 'Package deletion predicted. Aborting sync to S3 for manual investigation.' >&2; exit 1; }
 
 echo "Copying new files to S3"
-rclone copy "${RCLONE_SYNC_OPTS[@]}" --ignore-existing || exit
+rclone copy "${RCLONE_SYNC_OPTS[@]}" --ignore-existing 2>&1 || exit
 
 echo "Replacing changed files then deleting on S3"
-rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after || exit
+rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
-curl --silent --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
-  | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" || exit
+curl --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+  | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which curl rclone >/dev/null || {
+  echo 'This script requires curl and rclone, found in the container "octopusdeploy/publish-linux".' >&2
+  exit 1
+}
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to publish to the external public feed.' >&2
   exit 1

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -33,18 +33,18 @@ curl --user "$CURL_USER" --request POST --fail \
   "https://octopusdeploy.jfrog.io/octopusdeploy/api/deb/reindex/$REPO_KEY?async=0" || exit
 
 echo "Preparing sync to S3"
-RCLONE_OPTS="--config=/dev/null --verbose --s3-provider=AWS --s3-env-auth=true --s3-region=us-east-1 --s3-acl=public-read"
-RCLONE_SYNC_OPTS=":http: ':s3:$BUCKET' --http-url='https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY' $RCLONE_OPTS \
-  --fast-list --update --use-server-modtime"
-rclone sync $RCLONE_SYNC_OPTS --dry-run --include=*.deb --max-delete=0 \
-  || { echo 'Package deletion detected. Aborting sync to S3 for manual investigation.'; exit 1; }
+RCLONE_OPTS=(--config=/dev/null --verbose --s3-provider=AWS --s3-env-auth=true --s3-region=us-east-1 --s3-acl=public-read)
+RCLONE_SYNC_OPTS=(:http: ":s3:$BUCKET" --http-url="https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY" "${RCLONE_OPTS[@]}" \
+  --fast-list --update --use-server-modtime)
+rclone sync "${RCLONE_SYNC_OPTS[@]}" --dry-run --include=*.deb --max-delete=0 \
+  || { echo 'Package deletion predicted. Aborting sync to S3 for manual investigation.'; exit 1; }
 
 echo "Copying new files to S3"
-rclone copy $RCLONE_SYNC_OPTS --ignore-existing || exit
+rclone copy "${RCLONE_SYNC_OPTS[@]}" --ignore-existing || exit
 
 echo "Replacing changed files then deleting on S3"
-rclone sync $RCLONE_SYNC_OPTS --delete-after || exit
+rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after || exit
 
 echo "Asserting current public key on S3"
 curl --silent --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
-  | rclone rcat ":s3:$BUCKET/public.key" $RCLONE_OPTS || exit
+  | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" || exit

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -47,5 +47,5 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
-curl --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+curl --location --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" \
-   || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, PUBLISH_ARTIFACTORY_USERNAME, PUBLISH_ARTIFACTORY_PASSWORD, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to publish to the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" ]]; then
+  echo -e 'This script requires the environment variables PUBLISH_ARTIFACTORY_USERNAME and PUBLISH_ARTIFACTORY_PASSWORD - an account on'\
+    '\nthe artifactory instance with permissions up to "Manage" on the apt repos.' >&2
+  exit 1
+fi
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+  echo -e 'This script requires the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY - credentials to sync repo updates'\
+    '\nto S3.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -47,5 +47,5 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
-curl --location --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+curl --silent --show-error --fail --location https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -36,11 +36,11 @@ repo_gpgcheck=1
 echo "[tentacle]
 name=Octopus Tentacle
 $REPO_BODY" | curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file - \
-  "https://octopusdeploy.jfrog.io/octopusdeploy/rpm-prerelease/tentacle.repo" || exit
+  "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/tentacle.repo" || exit
 echo "[octopuscli]
 name=Octopus CLI
 $REPO_BODY" | curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file - \
-  "https://octopusdeploy.jfrog.io/octopusdeploy/rpm-prerelease/octopuscli.repo" || exit
+  "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/octopuscli.repo" || exit
 
 echo "Uploading package to Artifactory"
 PKG=$(ls -1 *.rpm | head -n1)

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -50,8 +50,6 @@ curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file "$PKG" \
   || exit
 
 echo "Waiting for reindex"
-sleep 5
-# Note: reindex is automatic, but triggering it synchronously provides an indication when it has completed
 curl "${CURL_UPL_OPTS[@]}" --request POST \
   "https://octopusdeploy.jfrog.io/octopusdeploy/api/yum/$REPO_KEY?async=0" || exit
 

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,53 +1,64 @@
 #!/bin/bash
 
-# Required env vars:
-#export AWS_ACCESS_KEY_ID=$(get_octopusvariable "OctopusToolsAwsAccount.AccessKey")
-#export AWS_SECRET_ACCESS_KEY=$(get_octopusvariable "OctopusToolsAwsAccount.SecretKey")
-#export S3_PUBLISH_ENDPOINT=$(get_octopusvariable "Publish.RPM.S3.TargetBucket")
-
-if [ ! -z "${DEBUG}" ]; then
-  set -x
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" \
+   || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  PUBLISH_LINUX_EXTERNAL, PUBLISH_ARTIFACTORY_USERNAME, PUBLISH_ARTIFACTORY_PASSWORD, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY'
 fi
 
-DEPENDENCIES=("aws" "createrepo")
-for dep in "${DEPENDENCIES[@]}"
-do
-  if [ ! $(which ${dep}) ]; then
-      echo "${dep} must be available."
-      exit 1
-  fi
-done
+if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
+  REPO_KEY='rpm'
+  BUCKET='rpm.octopus.com'
+  ORIGIN="https://$BUCKET"
+else
+  REPO_KEY='rpm-prerelease'
+  BUCKET='prerelease.rpm.octopus.com'
+  ORIGIN="http://$BUCKET"
+fi
+CURL_USER="$PUBLISH_ARTIFACTORY_USERNAME:$PUBLISH_ARTIFACTORY_PASSWORD"
 
-echo "Configuring S3 bucket"
-#aws s3 mb "s3://${S3_PUBLISH_ENDPOINT}" || exit 1
-#aws s3api wait bucket-exists --bucket ${S3_PUBLISH_ENDPOINT} || exit 1
-#aws s3 sync ./rpm-content "s3://${S3_PUBLISH_ENDPOINT}" --acl public-read || exit 1
-echo -e "[octopuscli]
-name=Octopus CLI
-baseurl=https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/\$basearch/
+echo "Uploading config to Artifactory"
+REPO_BODY="baseurl=$ORIGIN/\$basearch/
 enabled=1
-gpgkey=https://s3.amazonaws.com/$S3_PUBLISH_ENDPOINT/public.key
+gpgkey=$ORIGIN/public.key
 gpgcheck=0
-" > octopuscli.repo
-aws s3 cp octopuscli.repo "s3://${S3_PUBLISH_ENDPOINT}/octopuscli.repo" --acl public-read || exit
+repo_gpgcheck=1
+"
+echo "[tentacle]
+name=Octopus Tentacle
+$REPO_BODY" | curl --user "$CURL_USER" --request PUT --upload-file - --fail \
+  "https://octopusdeploy.jfrog.io/octopusdeploy/rpm-prerelease/tentacle.repo" || exit
+echo "[octopuscli]
+name=Octopus CLI
+$REPO_BODY" | curl --user "$CURL_USER" --request PUT --upload-file - --fail \
+  "https://octopusdeploy.jfrog.io/octopusdeploy/rpm-prerelease/octopuscli.repo" || exit
 
-TARGET_DIR="/tmp/$S3_PUBLISH_ENDPOINT"
+echo "Uploading package to Artifactory"
+PKG=$(ls -1 *.rpm | head -n1)
+PKGBN=$(basename "$PKG")
+curl --user "$CURL_USER" --request PUT --upload-file "$PKG" --fail \
+  "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/x86_64/$PKGBN" \
+  || exit
 
-# make sure we're operating on the latest data in the target bucket
-rm -rf "$TARGET_DIR" || exit
-mkdir -p "$TARGET_DIR" || exit
-aws s3 sync "s3://$S3_PUBLISH_ENDPOINT" "$TARGET_DIR" || exit
+echo "Waiting for reindex"
+sleep 5
+# Note: reindex is automatic, but triggering it synchronously provides an indication when it has completed
+curl --user "$CURL_USER" --request POST --fail \
+  "https://octopusdeploy.jfrog.io/octopusdeploy/api/yum/$REPO_KEY?async=0" || exit
 
-# copy the RPM in and update the repo
-mkdir -pv "$TARGET_DIR/x86_64/" || exit
-cp -v OctopusTools.Packages.linux-x64/*.rpm "$TARGET_DIR/x86_64/" || exit
-UPDATE=""
-if [ -e "$TARGET_DIR/x86_64/repodata/repomd.xml" ]; then
-  UPDATE="--update "
-fi
-for a in "$TARGET_DIR/x86_64"; do
-  createrepo -v $UPDATE --deltas "$a/" || exit
-done
+echo "Preparing sync to S3"
+RCLONE_OPTS="--config=/dev/null --verbose --s3-provider=AWS --s3-env-auth=true --s3-region=us-east-1 --s3-acl=public-read"
+RCLONE_SYNC_OPTS=":http: ':s3:$BUCKET' --http-url='https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY' $RCLONE_OPTS \
+  --fast-list --update --use-server-modtime"
+rclone sync $RCLONE_SYNC_OPTS --dry-run --include=*.rpm --max-delete=0 \
+  || { echo 'Package deletion detected. Aborting sync to S3 for manual investigation.'; exit 1; }
 
-# sync the repo state back to s3
-aws s3 sync "$TARGET_DIR" "s3://$S3_PUBLISH_ENDPOINT" --acl public-read --delete || exit
+echo "Copying new files to S3"
+rclone copy $RCLONE_SYNC_OPTS --ignore-existing || exit
+
+echo "Replacing changed files then deleting on S3"
+rclone sync $RCLONE_SYNC_OPTS --delete-after || exit
+
+echo "Asserting current public key on S3"
+curl --silent --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+  | rclone rcat ":s3:$BUCKET/public.key" $RCLONE_OPTS || exit

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -61,5 +61,5 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
-curl --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+curl --location --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -47,7 +47,7 @@ $REPO_BODY" | curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file - \
   "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/octopuscli.repo" || exit
 
 echo "Uploading package to Artifactory"
-PKG=$(ls -1 *.rpm | head -n1)
+PKG=$(set -o pipefail; ls -1 *.rpm | head -n1) || exit
 PKGBN=$(basename "$PKG")
 curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file "$PKG" \
   "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/x86_64/$PKGBN" \
@@ -71,5 +71,7 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
+set -o pipefail
 curl --silent --show-error --fail --location https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit
+set +o pipefail

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which curl rclone >/dev/null || {
+  echo 'This script requires curl and rclone, found in the container "octopusdeploy/publish-linux".' >&2
+  exit 1
+}
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to publish to the external public feed.' >&2
   exit 1

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -61,5 +61,5 @@ echo "Replacing changed files then deleting on S3"
 rclone sync "${RCLONE_SYNC_OPTS[@]}" --delete-after 2>&1 || exit
 
 echo "Asserting current public key on S3"
-curl --location --silent --show-error --fail https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
+curl --silent --show-error --fail --location https://octopusdeploy.jfrog.io/octopusdeploy/api/gpg/key/public \
   | rclone rcat ":s3:$BUCKET/public.key" "${RCLONE_OPTS[@]}" 2>&1 || exit

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" \
-   || -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, PUBLISH_ARTIFACTORY_USERNAME, PUBLISH_ARTIFACTORY_PASSWORD, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to publish to the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$PUBLISH_ARTIFACTORY_USERNAME" || -z "$PUBLISH_ARTIFACTORY_PASSWORD" ]]; then
+  echo -e 'This script requires the environment variables PUBLISH_ARTIFACTORY_USERNAME and PUBLISH_ARTIFACTORY_PASSWORD - an account on'\
+    '\nthe artifactory instance with permissions up to "Manage" on the apt repos.' >&2
+  exit 1
+fi
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+  echo -e 'This script requires the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY - credentials to sync repo updates'\
+    '\nto S3.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/publish-rpm.sh
+++ b/BuildAssets/repos/publish-rpm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Publish the first .rpm in the working directory to an Artifactory rpm repository, then sync the repository to S3.
 
 which curl rclone >/dev/null || {
   echo 'This script requires curl and rclone, found in the container "octopusdeploy/publish-linux".' >&2

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Smoke test one of our apt feeds in various dockerized distros.
 
 which docker >/dev/null || {
   echo 'This script requires docker.' >&2

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -10,7 +10,7 @@ fi
 test_in_docker () {
   echo "# Testing in '$1'"
   docker pull "$1" >/dev/null || exit
-  docker run --rm --volume $(pwd):/pkgs \
+  docker run --rm --volume $(pwd):/pkgs --hostname "testapt$RANDOM" \
     --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
     "$1" bash -c 'cd /pkgs && bash test-apt.sh' || exit
 }

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which docker >/dev/null || {
+  echo 'This script requires docker.' >&2
+  exit 1
+}
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
   exit 1

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -9,6 +9,7 @@ fi
 
 test_in_docker () {
   echo "# Testing in '$1'"
+  docker pull "$1" >/dev/null || exit
   docker run --rm --volume $(pwd):/pkgs \
     --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
     "$1" bash -c 'cd /pkgs && bash test-apt.sh' || exit

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
-   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
+    '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\
+    '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/test-apt-dists.sh
+++ b/BuildAssets/repos/test-apt-dists.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
+   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  exit 1
+fi
+
+test_in_docker () {
+  echo "# Testing in '$1'"
+  docker run --rm --volume $(pwd):/pkgs \
+    --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
+    "$1" bash -c 'cd /pkgs && bash test-apt.sh' || exit
+}
+
+test_in_docker debian:stable-slim
+test_in_docker ubuntu:latest
+if [ -n "$TEST_QUICK" ]; then
+  echo "TEST_QUICK is enabled. Skipping the remaining distros."
+  exit 0
+fi
+test_in_docker debian:oldstable-slim
+test_in_docker ubuntu:rolling
+test_in_docker linuxmintd/mint19.3-amd64
+test_in_docker ubuntu:xenial
+test_in_docker debian:oldoldstable-slim
+test_in_docker ubuntu:trusty

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-# This script requires environment variables to run:
-#   S3_PUBLISH_ENDPOINT, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$DEB_DIST" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  PUBLISH_LINUX_EXTERNAL, DEB_DIST, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+fi
+
+if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
+  ORIGIN="https://apt.octopus.com"
+else
+  ORIGIN="http://prerelease.apt.octopus.com"
+fi
 
 # Configure apt
 export DEBIAN_FRONTEND=noninteractive
 apt-get update --quiet 2 || exit
 apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
 apt-get install --no-install-recommends --yes gnupg curl software-properties-common >/dev/null || exit
-apt-key adv --fetch-keys "http://$S3_PUBLISH_ENDPOINT/public.key" 2>&1 || exit
-add-apt-repository "deb http://$S3_PUBLISH_ENDPOINT/ stretch main" || exit
+apt-key adv --fetch-keys "$ORIGIN/public.key" 2>&1 || exit
+add-apt-repository "deb $ORIGIN/ $DEB_DIST main" || exit
 apt-get update --quiet 2 || exit
 
 # Install

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -23,7 +23,7 @@ DIST=$({ grep --perl --no-filename --only-matching --no-messages \
   '^deb\s+(\[[^\]#]*?\]\s+)?[^\s#]+(debian|ubuntu)[^\s#]*\s+\K\w+' /etc/apt/sources.list /etc/apt/sources.list.d/* \
   | sort | uniq --count | sort --reverse --numeric; echo 0 stable; } | awk '{ print $2; exit; }')
 apt-get install --no-install-recommends --yes gnupg curl ca-certificates apt-transport-https >/dev/null || exit
-curl --silent --show-error --fail --location "$ORIGIN/public.key" | apt-key add - 2>&1 || exit
+curl --silent --show-error --fail --location "$ORIGIN/public.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - 2>&1 || exit
 echo "deb $ORIGIN/ $DIST main" > /etc/apt/sources.list.d/octopus.com.list || exit
 apt-get update --quiet 2 || exit
 

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$DEB_DIST" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
    || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, DEB_DIST, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
   exit 1
 fi
 
@@ -14,23 +14,27 @@ else
 fi
 
 # Configure apt
+echo "## Configuring apt"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update --quiet 2 || exit
 apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
-apt-get install --no-install-recommends --yes gnupg curl software-properties-common >/dev/null || exit
-apt-key adv --fetch-keys "$ORIGIN/public.key" 2>&1 || exit
-add-apt-repository "deb $ORIGIN/ $DEB_DIST main" || exit
+
+DIST=$({ grep --perl --no-filename --only-matching --no-messages \
+  '^deb\s+(\[[^\]#]*?\]\s+)?[^\s#]+(debian|ubuntu)[^\s#]*\s+\K\w+' /etc/apt/sources.list /etc/apt/sources.list.d/* \
+  | sort | uniq --count | sort --reverse --numeric; echo 0 stable; } | awk '{ print $2; exit; }')
+apt-get install --no-install-recommends --yes gnupg curl ca-certificates apt-transport-https >/dev/null || exit
+curl --silent --show-error --fail --location "$ORIGIN/public.key" | apt-key add - 2>&1 || exit
+echo "deb $ORIGIN/ $DIST main" > /etc/apt/sources.list.d/octopus.com.list || exit
 apt-get update --quiet 2 || exit
 
 # Install
 apt-get install --no-install-recommends --yes tentacle octopuscli >/dev/null || exit
 
 # Test
-echo "== Testing Tentacle =="
+echo "## Testing Tentacle"
 /opt/octopus/tentacle/Tentacle version || exit
 echo
-echo "== Testing Octopus CLI =="
+echo "## Testing Octopus CLI"
 octo version || exit
-apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
 OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
 echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -22,7 +22,8 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update --quiet 2 || exit
 apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
 
-# The following should be kept in sync with our documented download instructions (but more automated and quieter).
+# The following commands are intended to test our instructions at: https://octopus.com/downloads/octopuscli
+# Keep the process similar to how they might be applied (in a more automatic and quiet way)
 
 echo "## Configuring apt"
 DIST=$({ grep --perl --no-filename --only-matching --no-messages \

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$DEB_DIST" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$DEB_DIST" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
+   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, DEB_DIST, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+  PUBLISH_LINUX_EXTERNAL, DEB_DIST, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  exit 1
 fi
 
 if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -13,12 +13,14 @@ else
   ORIGIN="http://prerelease.apt.octopus.com"
 fi
 
-# Configure apt
-echo "## Configuring apt"
+# Configure docker environment
 export DEBIAN_FRONTEND=noninteractive
 apt-get update --quiet 2 || exit
 apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit # silence debconf warnings
 
+# The following should be kept in sync with our documented download instructions (but more automated and quieter).
+
+echo "## Configuring apt"
 DIST=$({ grep --perl --no-filename --only-matching --no-messages \
   '^deb\s+(\[[^\]#]*?\]\s+)?[^\s#]+(debian|ubuntu)[^\s#]*\s+\K\w+' /etc/apt/sources.list /etc/apt/sources.list.d/* \
   | sort | uniq --count | sort --reverse --numeric; echo 0 stable; } | awk '{ print $2; exit; }')
@@ -27,10 +29,9 @@ curl --silent --show-error --fail --location "$ORIGIN/public.key" | APT_KEY_DONT
 echo "deb $ORIGIN/ $DIST main" > /etc/apt/sources.list.d/octopus.com.list || exit
 apt-get update --quiet 2 || exit
 
-# Install
+echo "## Installing tentacle, octopuscli"
 apt-get install --no-install-recommends --yes tentacle octopuscli >/dev/null || exit
 
-# Test
 echo "## Testing Tentacle"
 /opt/octopus/tentacle/Tentacle version || exit
 echo

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
-   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
+    '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\
+    '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -22,7 +22,7 @@ apt-get install --no-install-recommends --yes apt-utils >/dev/null 2>&1 || exit 
 DIST=$({ grep --perl --no-filename --only-matching --no-messages \
   '^deb\s+(\[[^\]#]*?\]\s+)?[^\s#]+(debian|ubuntu)[^\s#]*\s+\K\w+' /etc/apt/sources.list /etc/apt/sources.list.d/* \
   | sort | uniq --count | sort --reverse --numeric; echo 0 stable; } | awk '{ print $2; exit; }')
-apt-get install --no-install-recommends --yes gnupg curl ca-certificates apt-transport-https >/dev/null || exit
+apt-get install --no-install-recommends --yes gnupg curl ca-certificates apt-transport-https 2>&1 >/dev/null || exit
 curl --silent --show-error --fail --location "$ORIGIN/public.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - 2>&1 || exit
 echo "deb $ORIGIN/ $DIST main" > /etc/apt/sources.list.d/octopus.com.list || exit
 apt-get update --quiet 2 || exit

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -30,7 +30,9 @@ DIST=$({ grep --perl --no-filename --only-matching --no-messages \
   '^deb\s+(\[[^\]#]*?\]\s+)?[^\s#]+(debian|ubuntu)[^\s#]*\s+\K\w+' /etc/apt/sources.list /etc/apt/sources.list.d/* \
   | sort | uniq --count | sort --reverse --numeric; echo 0 stable; } | awk '{ print $2; exit; }')
 apt-get install --no-install-recommends --yes gnupg curl ca-certificates apt-transport-https 2>&1 >/dev/null || exit
+set -o pipefail
 curl --silent --show-error --fail --location "$ORIGIN/public.key" | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add - 2>&1 || exit
+set +o pipefail
 echo "deb $ORIGIN/ $DIST main" > /etc/apt/sources.list.d/octopus.com.list || exit
 apt-get update --quiet 2 || exit
 

--- a/BuildAssets/repos/test-apt.sh
+++ b/BuildAssets/repos/test-apt.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Install tentacle, octopuscli from one of our apt feeds, and perform a basic smoke test.
 
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -15,7 +15,7 @@ fi
 test_in_docker () {
   echo "# Testing in '$1'"
   docker pull "$1" >/dev/null || exit
-  docker run --rm --volume $(pwd):/pkgs \
+  docker run --rm --volume $(pwd):/pkgs --hostname "testrpm$RANDOM" \
     --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
     --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \
     "$1" bash -c 'cd /pkgs && bash test-rpm.sh' || exit

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -25,8 +25,8 @@ test_in_docker () {
   echo "# Testing in '$1'"
   docker pull "$1" >/dev/null || exit
   docker run --rm --volume $(pwd):/pkgs --hostname "testrpm$RANDOM" \
-    --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
-    --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \
+    --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
+    --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \
     "$1" bash -c 'cd /pkgs && bash test-rpm.sh' || exit
 }
 

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which docker >/dev/null || {
+  echo 'This script requires docker.' >&2
+  exit 1
+}
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
   exit 1

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -14,6 +14,7 @@ fi
 
 test_in_docker () {
   echo "# Testing in '$1'"
+  docker pull "$1" >/dev/null || exit
   docker run --rm --volume $(pwd):/pkgs \
     --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
     --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Smoke test one of our rpm feeds in various dockerized distros.
 
 which docker >/dev/null || {
   echo 'This script requires docker.' >&2

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
+   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  exit 1
+fi
+if [[ -z "$TEST_QUICK" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
+  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD,
+or TEST_QUICK to skip some distributions.' >&2
+  exit 1
+fi
+
+test_in_docker () {
+  echo "# Testing in '$1'"
+  docker run --rm --volume $(pwd):/pkgs \
+    --env PUBLISH_LINUX_EXTERNAL --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
+    --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \
+    "$1" bash -c 'cd /pkgs && bash test-rpm.sh' || exit
+}
+
+test_in_docker centos:latest
+if [ -n "$TEST_QUICK" ]; then
+  echo "TEST_QUICK is enabled. Skipping the remaining distros."
+  exit 0
+fi
+test_in_docker fedora:latest
+test_in_docker centos:7
+test_in_docker roboxes/rhel8
+test_in_docker roboxes/rhel7

--- a/BuildAssets/repos/test-rpm-dists.sh
+++ b/BuildAssets/repos/test-rpm-dists.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
-   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
+    '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\
+    '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
 if [[ -z "$TEST_QUICK" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
-  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD,
-or TEST_QUICK to skip some distributions.' >&2
+  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD to register'\
+    '\na test system, or TEST_QUICK set to any value to skip Red Hat and some other distributions.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -14,17 +14,36 @@ else
 fi
 
 # Configure yum
+echo "## Configuring yum"
 curl --silent --show-error --fail --location "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
 curl --silent --show-error --fail --location "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
-# Install
-yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit
+echo "## Installing tentacle, octopuscli"
+if [[ $(. /etc/os-release && echo $ID) != "rhel" ]]; then
+  # Install
+  yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit
+else
+  if [[ -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ]]; then
+    echo -e 'Unable to test in RHEL without environment variables: REDHAT_SUBSCRIPTION_USERNAME, REDHAT_SUBSCRIPTION_PASSWORD.' >&2
+    exit 1
+  fi
+
+  # Install
+  subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
+    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || exit
+  yum --quiet --assumeyes install tentacle octopuscli >/dev/null 2>&1
+  STATUS=$?
+  subscription-manager unsubscribe --all >/dev/null 2>&1 || exit
+  if [[ $STATUS -ne 0 ]]; then
+    exit $STATUS
+  fi
+fi
 
 # Test
-echo "== Testing Tentacle =="
+echo "## Testing Tentacle"
 /opt/octopus/tentacle/Tentacle version || exit
 echo
-echo "== Testing Octopus CLI =="
+echo "## Testing Octopus CLI"
 octo version || exit
 OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
 echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -14,8 +14,8 @@ else
 fi
 
 # Configure yum
-curl --location --silent --show-error --fail "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
-curl --location --silent --show-error --fail "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
+curl --silent --show-error --fail --location "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
+curl --silent --show-error --fail --location "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
 # Install
 yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -13,22 +13,20 @@ else
   ORIGIN="http://prerelease.rpm.octopus.com"
 fi
 
-# Configure yum
+# The following should be kept in sync with our documented download instructions (but more automated and quieter).
+
 echo "## Configuring yum"
 curl --silent --show-error --fail --location "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
 curl --silent --show-error --fail --location "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
 echo "## Installing tentacle, octopuscli"
 if [[ $(. /etc/os-release && echo $ID) != "rhel" ]]; then
-  # Install
   yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit
 else
   if [[ -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ]]; then
     echo -e 'Unable to test in RHEL without environment variables: REDHAT_SUBSCRIPTION_USERNAME, REDHAT_SUBSCRIPTION_PASSWORD.' >&2
     exit 1
   fi
-
-  # Install
   subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
     --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || { echo "Red Hat subscribe problem." >&2; exit 1; }
   yum --quiet --assumeyes install tentacle octopuscli 2>&1 >/dev/null
@@ -39,7 +37,6 @@ else
   fi
 fi
 
-# Test
 echo "## Testing Tentacle"
 /opt/octopus/tentacle/Tentacle version || exit
 echo

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -14,8 +14,8 @@ else
 fi
 
 # Configure yum
-curl --silent --show-error --fail "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
-curl --silent --show-error --fail "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
+curl --location --silent --show-error --fail "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
+curl --location --silent --show-error --fail "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
 # Install
 yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -36,13 +36,18 @@ else
   #   - Register with Red Hat to enable yum
   #   - Install yum-plugin-ovl to reduce chance of "Rpmdb checksum is invalid"
   #   - Suppress output unless there is a failure, because yum is noisy in these RHEL containers
-  SUB_OUT="$(subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" --password "$REDHAT_SUBSCRIPTION_PASSWORD" \
-    --auto-attach 2>&1)" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
-  ERR_OUT="$(yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
-    yum --quiet --assumeyes install tentacle octopuscli 2>&1)"
+  SUB_OUT="$(
+    subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" --password "$REDHAT_SUBSCRIPTION_PASSWORD" \
+      --auto-attach 2>&1
+  )" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
+  ERR_OUT="$(
+    yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
+    yum --quiet --assumeyes install tentacle octopuscli 2>&1
+  )"
   STATUS=$?
-  SUB_OUT="$(subscription-manager unsubscribe --all 2>&1)" \
-    || { echo "Error while removing Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
+  SUB_OUT="$(
+    subscription-manager unsubscribe --all 2>&1
+  )" || { echo "Error while removing Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
   if [[ $STATUS -ne 0 ]]; then
     echo "Error while installing packages:" >&2
     echo "$ERR_OUT" >&2

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Install tentacle, octopuscli from one of our rpm feeds, and perform a basic smoke test.
 
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-# This script requires environment variables to run:
-#   S3_PUBLISH_ENDPOINT, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+fi
+
+if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
+  ORIGIN="https://rpm.octopus.com/"
+else
+  ORIGIN="http://prerelease.rpm.octopus.com/"
+fi
 
 # Configure yum
-curl -s "http://$S3_PUBLISH_ENDPOINT/tentacle.repo" -o /etc/yum.repos.d/tentacle.repo || exit
-curl -s "http://$S3_PUBLISH_ENDPOINT/octopuscli.repo" -o /etc/yum.repos.d/octopuscli.repo || exit
+curl --silent "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
+curl --silent "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
 # Install
-yum --quiet --assumeyes install tentacle 2>&1 || exit
-yum --quiet --assumeyes install octopuscli 2>&1 || exit
+yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit
 
 # Test
 echo "== Testing Tentacle =="

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
+   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  exit 1
 fi
 
 if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
@@ -12,8 +14,8 @@ else
 fi
 
 # Configure yum
-curl --silent "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
-curl --silent "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
+curl --silent --show-error --fail "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit
+curl --silent --show-error --fail "$ORIGIN/octopuscli.repo" --output /etc/yum.repos.d/octopuscli.repo || exit
 
 # Install
 yum --quiet --assumeyes install tentacle octopuscli 2>&1 || exit

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -30,10 +30,10 @@ else
 
   # Install
   subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
-    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || exit
-  yum --quiet --assumeyes install tentacle octopuscli >/dev/null 2>&1
+    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || { echo "Red Hat subscribe problem." >&2; exit 1; }
+  yum --quiet --assumeyes install tentacle octopuscli 2>&1 >/dev/null
   STATUS=$?
-  subscription-manager unsubscribe --all >/dev/null 2>&1 || exit
+  subscription-manager unsubscribe --all >/dev/null 2>&1 || { echo "Red Hat unsubscribe problem." >&2; exit 1; }
   if [[ $STATUS -ne 0 ]]; then
     exit $STATUS
   fi

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -8,9 +8,9 @@ if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_C
 fi
 
 if [[ "$PUBLISH_LINUX_EXTERNAL" == "true" ]]; then
-  ORIGIN="https://rpm.octopus.com/"
+  ORIGIN="https://rpm.octopus.com"
 else
-  ORIGIN="http://prerelease.rpm.octopus.com/"
+  ORIGIN="http://prerelease.rpm.octopus.com"
 fi
 
 # Configure yum

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -41,7 +41,9 @@ else
       --auto-attach 2>&1
   )" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
   ERR_OUT="$(
-    yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
+    if [[ "$(source /etc/os-release && echo "${VERSION_ID:0:1}")" -lt 8 ]]; then
+      yum --quiet --assumeyes install yum-plugin-ovl 2>&1 || exit
+    fi
     yum --quiet --assumeyes install tentacle octopuscli 2>&1
   )"
   STATUS=$?

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -17,7 +17,8 @@ else
   ORIGIN="http://prerelease.rpm.octopus.com"
 fi
 
-# The following should be kept in sync with our documented download instructions (but more automated and quieter).
+# The following commands are intended to test our instructions at: https://octopus.com/downloads/octopuscli
+# Keep the process similar to how they might be applied (in a more automatic and quiet way)
 
 echo "## Configuring yum"
 curl --silent --show-error --fail --location "$ORIGIN/tentacle.repo" --output /etc/yum.repos.d/tentacle.repo || exit

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-if [[ -z "$PUBLISH_LINUX_EXTERNAL" || -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" \
-   || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  PUBLISH_LINUX_EXTERNAL, OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
+  echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
+  exit 1
+fi
+if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
+    '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\
+    '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/test-rpm.sh
+++ b/BuildAssets/repos/test-rpm.sh
@@ -27,12 +27,20 @@ else
     echo -e 'Unable to test in RHEL without environment variables: REDHAT_SUBSCRIPTION_USERNAME, REDHAT_SUBSCRIPTION_PASSWORD.' >&2
     exit 1
   fi
-  subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
-    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || { echo "Red Hat subscribe problem." >&2; exit 1; }
-  yum --quiet --assumeyes install tentacle octopuscli 2>&1 >/dev/null
+  # Install our packages, but first:
+  #   - Register with Red Hat to enable yum
+  #   - Install yum-plugin-ovl to reduce chance of "Rpmdb checksum is invalid"
+  #   - Suppress output unless there is a failure, because yum is noisy in these RHEL containers
+  SUB_OUT="$(subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" --password "$REDHAT_SUBSCRIPTION_PASSWORD" \
+    --auto-attach 2>&1)" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
+  ERR_OUT="$(yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
+    yum --quiet --assumeyes install tentacle octopuscli 2>&1)"
   STATUS=$?
-  subscription-manager unsubscribe --all >/dev/null 2>&1 || { echo "Red Hat unsubscribe problem." >&2; exit 1; }
+  SUB_OUT="$(subscription-manager unsubscribe --all 2>&1)" \
+    || { echo "Error while removing Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
   if [[ $STATUS -ne 0 ]]; then
+    echo "Error while installing packages:" >&2
+    echo "$ERR_OUT" >&2
     exit $STATUS
   fi
 fi

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -27,7 +27,7 @@ TEST_DEB_SH='
 
   # Install octo
   dpkg -i /pkgs/octopuscli*.deb >/dev/null 2>&1 # Silenced and expected to fail due to missing deps, which apt can fix
-  apt-get --no-install-recommends --yes --fix-broken install >/dev/null 2>&1 || exit
+  apt-get --no-install-recommends --yes --fix-broken install 2>&1 >/dev/null || exit
   apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
 '"$TEST_SH"
 

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -49,7 +49,6 @@ else
       --auto-attach 2>&1
   )" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
   ERR_OUT="$(
-    yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
     yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1
   )"
   STATUS=$?

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -2,11 +2,13 @@
 
 if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the following environment variables to be set:
-  OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+  OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  exit 1
 fi
 if [[ -z "$TEST_QUICK" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
   echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD,
-or TEST_QUICK to skip some distributions.'
+or TEST_QUICK to skip some distributions.' >&2
+  exit 1
 fi
 
 TEST_DEB_SH='
@@ -52,8 +54,8 @@ TEST_RHEL_SH='
 test_in_docker () {
   echo "== Testing $1 =="
   docker pull "$1" >/dev/null || exit
-  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \
-    --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit
+  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
+    --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit
 }
 
 test_in_docker debian:stable-slim "$TEST_DEB_SH"

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
 if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
-  echo -e 'This script requires the following environment variables to be set:
-  OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV' >&2
+  echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
+    '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\
+    '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
 if [[ -z "$TEST_QUICK" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
-  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD,
-or TEST_QUICK to skip some distributions.' >&2
+  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD to register'\
+    '\na test system, or TEST_QUICK set to any value to skip Red Hat and some other distributions.' >&2
   exit 1
 fi
 

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Test that .deb and .rpm packages in the working directory install an octo command that can list-environments.
 
 which docker >/dev/null || {
   echo 'This script requires docker.' >&2

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -48,7 +48,7 @@ fi
 '"$TEST_SH"
 
 test_in_docker () {
-  echo "== Testing $1 =="
+  echo "== Testing in '$1' =="
   docker pull "$1" >/dev/null || exit
   docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
     --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -37,10 +37,10 @@ if [[ $(. /etc/os-release && echo $ID) != "rhel" ]]; then
 else
   # Install octo
   subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" \
-    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || exit
-  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm >/dev/null 2>&1
+    --password "$REDHAT_SUBSCRIPTION_PASSWORD" --auto-attach >/dev/null 2>&1 || { echo "Red Hat subscribe problem." >&2; exit 1; }
+  yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1 >/dev/null
   STATUS=$?
-  subscription-manager unsubscribe --all >/dev/null 2>&1 || exit
+  subscription-manager unsubscribe --all >/dev/null 2>&1 || { echo "Red Hat unsubscribe problem." >&2; exit 1; }
   if [[ $STATUS -ne 0 ]]; then
     exit $STATUS
   fi

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+which docker >/dev/null || {
+  echo 'This script requires docker.' >&2
+  exit 1
+}
 if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
     '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -44,13 +44,18 @@ else
   #   - Register with Red Hat to enable yum
   #   - Install yum-plugin-ovl to reduce chance of "Rpmdb checksum is invalid"
   #   - Suppress output unless there is a failure, because yum is noisy in these RHEL containers
-  SUB_OUT="$(subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" --password "$REDHAT_SUBSCRIPTION_PASSWORD" \
-    --auto-attach 2>&1)" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
-  ERR_OUT="$(yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
-    yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1)"
+  SUB_OUT="$(
+    subscription-manager register --username "$REDHAT_SUBSCRIPTION_USERNAME" --password "$REDHAT_SUBSCRIPTION_PASSWORD" \
+      --auto-attach 2>&1
+  )" || { echo "Error while registering Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
+  ERR_OUT="$(
+    yum --quiet --assumeyes install yum-plugin-ovl 2>&1 && \
+    yum --quiet --assumeyes localinstall /pkgs/octopuscli*.rpm 2>&1
+  )"
   STATUS=$?
-  SUB_OUT="$(subscription-manager unsubscribe --all 2>&1)" \
-    || { echo "Error while removing Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
+  SUB_OUT="$(
+    subscription-manager unsubscribe --all 2>&1
+  )" || { echo "Error while removing Red Hat subscription:" >&2; echo "$SUB_OUT" >&2; exit 1; }
   if [[ $STATUS -ne 0 ]]; then
     echo "Error while installing packages:" >&2
     echo "$ERR_OUT" >&2

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -57,8 +57,9 @@ fi
 test_in_docker () {
   echo "== Testing in '$1' =="
   docker pull "$1" >/dev/null || exit
-  docker run --rm --volume "$(pwd):/pkgs" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE \
-    --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD "$1" bash -c "$2" || exit
+  docker run --rm --volume "$(pwd):/pkgs" --hostname "testpkgs$RANDOM" --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY \
+    --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV --env REDHAT_SUBSCRIPTION_USERNAME --env REDHAT_SUBSCRIPTION_PASSWORD \
+    "$1" bash -c "$2" || exit
 }
 
 test_in_docker debian:stable-slim "$TEST_DEB_SH"

--- a/BuildAssets/test-linux-packages.sh
+++ b/BuildAssets/test-linux-packages.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-# This script requires environment variables to run:
-#   OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV
-# You must also supply either:
-#   TEST_QUICK (to skip some distributions)
-# or
-#   REDHAT_SUBSCRIPTION_USERNAME, REDHAT_SUBSCRIPTION_PASSWORD (to support RHEL tests)
+if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
+  echo -e 'This script requires the following environment variables to be set:
+  OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, OCTOPUS_EXPECT_ENV'
+fi
+if [[ -z "$TEST_QUICK" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
+  echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD,
+or TEST_QUICK to skip some distributions.'
+fi
 
 TEST_DEB_SH='
   # Configure apt

--- a/build.cake
+++ b/build.cake
@@ -393,7 +393,7 @@ private void SignBinaries(string path)
 
 	Sign(files, new SignToolSignSettings {
 			ToolPath = MakeAbsolute(File("./certificates/signtool.exe")),
-            TimeStampUri = new Uri("http://www.startssl.com/timestamp"),
+            TimeStampUri = new Uri("http://timestamp.verisign.com/scripts/timstamp.dll"),
             CertPath = signingCertificatePath,
             Password = signingCertificatePassword
     });

--- a/build.cake
+++ b/build.cake
@@ -351,7 +351,7 @@ Task("CreateLinuxPackages")
         Env = new string[] { 
             $"VERSION={nugetVersion}",
             "OCTOPUSCLI_BINARIES=/app/",
-            "ARTIFACTS=/out"
+            "OUT_PATH=/out"
         },
         Volume = new string[] { 
             $"{Environment.CurrentDirectory}/BuildAssets:/build",

--- a/build.cake
+++ b/build.cake
@@ -393,7 +393,7 @@ private void SignBinaries(string path)
 
 	Sign(files, new SignToolSignSettings {
 			ToolPath = MakeAbsolute(File("./certificates/signtool.exe")),
-            TimeStampUri = new Uri("http://timestamp.globalsign.com/scripts/timestamp.dll"),
+            TimeStampUri = new Uri("http://www.startssl.com/timestamp"),
             CertPath = signingCertificatePath,
             Password = signingCertificatePassword
     });

--- a/build.cake
+++ b/build.cake
@@ -369,7 +369,9 @@ Task("CreateLinuxPackages")
     CopyFileToDirectory($"{assetDir}/repos/publish-apt.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/publish-rpm.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/test-apt.sh", $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/test-apt-dists.sh", $"{artifactsDir}/linuxpackages");
     CopyFileToDirectory($"{assetDir}/repos/test-rpm.sh", $"{artifactsDir}/linuxpackages");
+    CopyFileToDirectory($"{assetDir}/repos/test-rpm-dists.sh", $"{artifactsDir}/linuxpackages");
     TarGzip($"{artifactsDir}/linuxpackages", $"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}");
     var buildSystem = BuildSystemAliases.BuildSystem(Context);
     buildSystem.TeamCity.PublishArtifacts($"{artifactsDir}/OctopusTools.Packages.linux-x64.{nugetVersion}.tar.gz");


### PR DESCRIPTION
# Background

Our existing process involves pulling everything down from S3, adding the new Octopus CLI or Tentacle package, regenerating the apt & yum feeds, and pushing back to S3.

It currently has some drawbacks:
- Quite slow & fragile
- Leaves open a wide window when Tentacle and Octopus CLI processes could come into conflict, as well as tension over which project "owns" the repos
- Yum repos are not signed
- The distribution specifier for apt is always `stretch`, which is overly specific and out of date

# Change

This change treats Artifactory as the owner of the feed state, with S3 as a backup. There is a safeguard included so we don't push to S3 from Artifactory if doing so would remove packages. If/when we actually want to remove a package, we will remove from both Artifactory and S3 to confirm that.

Yum repos are now signed.

Apt repos now support more distribution specifiers:  `oldoldstable` `oldstable` `stable` `jessie` `stretch` `buster` `trusty` `xenial` `bionic` `cosmic` `disco` `eoan`. This is more natural, and makes it possible for us to vary the payloads in future if we ever need to.

Artifactory creation isn't automated yet but is well documented in `BuildAssets/repos/README.md`.

More of the process is in version control than before, so TeamCity/Octopus scripts can focus on their concerns: passing in the right variables.

Testing and error checks have been expanded, so we test 13 distros can install using our advertised instructions.