### PR TITLE
Made all the command options use camelCase for consistency

### DIFF
--- a/source/Octo.Tests/Commands/OverrideAutoDeployCommandFixture.cs
+++ b/source/Octo.Tests/Commands/OverrideAutoDeployCommandFixture.cs
@@ -109,7 +109,7 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("-project=OctoFx");
             CommandLineArgs.Add("-environment=Production");
             CommandLineArgs.Add("-version=1.2.0");
-            CommandLineArgs.Add("-tenanttag=VIP");
+            CommandLineArgs.Add("-tenantTag=VIP");
 
             await createAutoDeployOverrideCommand.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
 
@@ -128,8 +128,8 @@ namespace Octo.Tests.Commands
             CommandLineArgs.Add("-project=OctoFx");
             CommandLineArgs.Add("-environment=Production");
             CommandLineArgs.Add("-version=1.2.0");
-            CommandLineArgs.Add("-tenanttag=VIP");
-            CommandLineArgs.Add("-outputformat=json");
+            CommandLineArgs.Add("-tenantTag=VIP");
+            CommandLineArgs.Add("-outputFormat=json");
 
             await createAutoDeployOverrideCommand.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
 

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -256,7 +256,7 @@ namespace Octopus.Cli.Commands
             }
             else
             {
-                throw new Exception("Need to override the Execute method or implement the ISuportFormattedOutput interface");
+                throw new Exception($"Need to override the Execute method or implement the {nameof(ISupportFormattedOutput)} interface");
             }
         }
 

--- a/source/Octopus.Cli/Commands/Deployment/CreateAutoDeployOverrideCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/CreateAutoDeployOverrideCommand.cs
@@ -35,7 +35,7 @@ namespace Octopus.Cli.Commands.Deployment
             options.Add("tenant=",
                 "[Optional] Name of a tenant the override will apply to. Specify this argument multiple times to add multiple tenants or use `*` wildcard for all tenants.",
                 t => TenantNames.Add(t));
-            options.Add("tenanttag=",
+            options.Add("tenantTag=",
                 "[Optional] A tenant tag used to match tenants that the override will apply to. Specify this argument multiple times to add multiple tenant tags",
                 tt => TenantTags.Add(tt));
 

--- a/source/Octopus.Cli/Commands/Deployment/DeleteAutoDeployOverrideCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeleteAutoDeployOverrideCommand.cs
@@ -29,7 +29,7 @@ namespace Octopus.Cli.Commands.Deployment
             options.Add("tenant=",
                 "[Optional] Name of a tenant the override will apply to. Specify this argument multiple times to add multiple tenants or use `*` wildcard for all tenants.",
                 t => TenantNames.Add(t));
-            options.Add("tenanttag=",
+            options.Add("tenantTag=",
                 "[Optional] A tenant tag used to match tenants that the override will apply to. Specify this argument multiple times to add multiple tenant tags",
                 tt => TenantTags.Add(tt));
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -22,7 +22,7 @@ namespace Octopus.Cli.Commands.Deployment
         {
             var options = Options.For("Deployment");
             options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("deployTo=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelNameOrId = v);
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
@@ -35,7 +35,7 @@ namespace Octopus.Cli.Commands.Deployment
 
         protected override async Task ValidateParameters()
         {
-            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
+            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployTo=XYZ");
             if (string.IsNullOrWhiteSpace(VersionNumber)) throw new CommandException("Please specify a release version using the parameter: --version=1.0.0.0 or --version=latest for the latest release");
             if (!string.IsNullOrWhiteSpace(ChannelNameOrId) && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel argument.");
 

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -35,23 +35,23 @@ namespace Octopus.Cli.Commands.Deployment
 
             var options = Options.For("Deployment");
             options.Add("progress", "[Optional] Show progress of the deployment", v => { showProgress = true; WaitForDeployment = true; noRawLog = true; });
-            options.Add("forcepackagedownload", "[Optional] Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
-            options.Add("waitfordeployment", "[Optional] Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
-            options.Add("deploymenttimeout=", "[Optional] Specifies maximum time (timespan format) that the console session will wait for the deployment to finish(default 00:10:00). This will not stop the deployment. Requires --waitfordeployment parameter set.", v => DeploymentTimeout = TimeSpan.Parse(v));
-            options.Add("cancelontimeout", "[Optional] Whether to cancel the deployment if the deployment timeout is reached (flag, default false).", v => CancelOnTimeout = true);
-            options.Add("deploymentchecksleepcycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = TimeSpan.Parse(v));
-            options.Add("guidedfailure=", "[Optional] Whether to use guided failure mode. (True or False. If not specified, will use default setting from environment)", v => UseGuidedFailure = bool.Parse(v));
-            options.Add("specificmachines=", "[Optional] A comma-separated list of machine names to target in the deployed environment. If not specified all machines in the environment will be considered.", v => SpecificMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
-            options.Add("excludemachines=", "[Optional] A comma-separated list of machine names to exclude in the deployed environment. If not specified all machines in the environment will be considered.", v => ExcludedMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
+            options.Add("forcePackageDownload", "[Optional] Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
+            options.Add("waitForDeployment", "[Optional] Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
+            options.Add("deploymentTimeout=", "[Optional] Specifies maximum time (timespan format) that the console session will wait for the deployment to finish(default 00:10:00). This will not stop the deployment. Requires --waitForDeployment parameter set.", v => DeploymentTimeout = TimeSpan.Parse(v));
+            options.Add("cancelOnTimeout", "[Optional] Whether to cancel the deployment if the deployment timeout is reached (flag, default false).", v => CancelOnTimeout = true);
+            options.Add("deploymentCheckSleepCycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = TimeSpan.Parse(v));
+            options.Add("guidedFailure=", "[Optional] Whether to use guided failure mode. (True or False. If not specified, will use default setting from environment)", v => UseGuidedFailure = bool.Parse(v));
+            options.Add("specificMachines=", "[Optional] A comma-separated list of machine names to target in the deployed environment. If not specified all machines in the environment will be considered.", v => SpecificMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
+            options.Add("excludeMachines=", "[Optional] A comma-separated list of machine names to exclude in the deployed environment. If not specified all machines in the environment will be considered.", v => ExcludedMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
             options.Add("force", "[Optional] If a project is configured to skip packages with already-installed versions, override this setting to force re-deployment (flag, default false).", v => ForcePackageRedeployment = true);
             options.Add("skip=", "[Optional] Skip a step by name", v => SkipStepNames.Add(v));
-            options.Add("norawlog", "[Optional] Don't print the raw log of failed tasks", v => noRawLog = true);
-            options.Add("rawlogfile=", "[Optional] Redirect the raw log of failed tasks to a file", v => rawLogFile = v);
+            options.Add("noRawLog", "[Optional] Don't print the raw log of failed tasks", v => noRawLog = true);
+            options.Add("rawLogFile=", "[Optional] Redirect the raw log of failed tasks to a file", v => rawLogFile = v);
             options.Add("v|variable=", "[Optional] Values for any prompted variables in the format Label:Value. For JSON values, embedded quotation marks should be escaped with a backslash.", ParseVariable);
-            options.Add("deployat=", "[Optional] Time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => DeployAt = ParseDateTimeOffset(v));
-            options.Add("nodeployafter=", "[Optional] Time at which scheduled deployment should expire, specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => NoDeployAfter = ParseDateTimeOffset(v));
+            options.Add("deployAt=", "[Optional] Time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => DeployAt = ParseDateTimeOffset(v));
+            options.Add("noDeployAfter=", "[Optional] Time at which scheduled deployment should expire, specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => NoDeployAfter = ParseDateTimeOffset(v));
             options.Add("tenant=", "Create a deployment for the tenant with this name or ID; specify this argument multiple times to add multiple tenants or use `*` wildcard to deploy to all tenants who are ready for this release (according to lifecycle).", t => Tenants.Add(t));
-            options.Add("tenanttag=", "Create a deployment for tenants matching this tag; specify this argument multiple times to build a query/filter with multiple tags, just like you can in the user interface.", tt => TenantTags.Add(tt));
+            options.Add("tenantTag=", "Create a deployment for tenants matching this tag; specify this argument multiple times to build a query/filter with multiple tags, just like you can in the user interface.", tt => TenantTags.Add(tt));
         }
 
         protected bool ForcePackageRedeployment { get; set; }
@@ -84,7 +84,7 @@ namespace Octopus.Cli.Commands.Deployment
             if (IsTenantedDeployment && DeployToEnvironmentNamesOrIds.Count > 1) throw new CommandException("Please specify only one environment at a time when deploying to tenants.");
             if (Tenants.Contains("*") && (Tenants.Count > 1 || TenantTags.Count > 0)) throw new CommandException("When deploying to all tenants using --tenant=* wildcard no other tenant filters can be provided");
             if (IsTenantedDeployment && !await Repository.SupportsTenants().ConfigureAwait(false))
-                throw new CommandException("Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
+                throw new CommandException("Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenantTag arguments.");
             if ((DeployAt ?? DateTimeOffset.Now) > NoDeployAfter)
                 throw new CommandException("The deployment will expire before it has a chance to execute.  Please select an expiry time that occurs after the deployment is scheduled to begin");
 

--- a/source/Octopus.Cli/Commands/Environment/CleanEnvironmentCommand.cs
+++ b/source/Octopus.Cli/Commands/Environment/CleanEnvironmentCommand.cs
@@ -34,7 +34,7 @@ namespace Octopus.Cli.Commands.Environment
             var options = Options.For("Cleanup");
             options.Add("environment=", "Name of an environment to clean up.", v => environmentName = v);
             options.Add("status=", $"Status of Machines clean up ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
-            options.Add("health-status=|healthstatus=", $"Health status of Machines to clean up ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
+            options.Add("health-status=|healthStatus=", $"Health status of Machines to clean up ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
             options.Add("disabled=", "[Optional] Disabled status filter of Machine to clean up.", v => SetFlagState(v, ref isDisabled));
             options.Add("calamari-outdated=", "[Optional] State of Calamari to clean up. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));
             options.Add("tentacle-outdated=", "[Optional] State of Tentacle version to clean up. By default ignores Tentacle state", v => SetFlagState(v, ref isTentacleOutdated));

--- a/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
+++ b/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
@@ -52,7 +52,7 @@ namespace Octopus.Cli.Commands
 
         public Task Execute(string[] commandLineArguments)
         {
-            var invalidShellSelectionMessage = $"Please specify the type of shell to install autocompletion for: --shell=XYZ. Valid values are {supportedShells}.";
+            var invalidShellSelectionMessage = $"Please specify the type of shell to install auto-completion for: --shell=XYZ. Valid values are {supportedShells}.";
             Options.Parse(commandLineArguments);
             if (ShellSelection == SupportedShell.Unspecified) throw new CommandException(invalidShellSelectionMessage);
 

--- a/source/Octopus.Cli/Commands/Machine/ListMachinesCommand.cs
+++ b/source/Octopus.Cli/Commands/Machine/ListMachinesCommand.cs
@@ -31,7 +31,7 @@ namespace Octopus.Cli.Commands.Machine
             var options = Options.For("Listing");
             options.Add("environment=", "Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
             options.Add("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
-            options.Add("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
+            options.Add("health-status=|healthStatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
             options.Add("disabled=", "[Optional] Disabled status filter of Machine.", v => SetFlagState(v, ref isDisabled));
             options.Add("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));
             options.Add("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => SetFlagState(v, ref isTentacleOutdated));

--- a/source/Octopus.Cli/Commands/Machine/ListWorkersCommand.cs
+++ b/source/Octopus.Cli/Commands/Machine/ListWorkersCommand.cs
@@ -28,9 +28,9 @@ namespace Octopus.Cli.Commands.Machine
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing Workers");
-            options.Add("workerpool=", "Name of a worker pool to filter by. Can be specified many times.", v => pools.Add(v));
+            options.Add("workerPool=", "Name of a worker pool to filter by. Can be specified many times.", v => pools.Add(v));
             options.Add("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
-            options.Add("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
+            options.Add("health-status=|healthStatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
             options.Add("disabled=", "[Optional] Disabled status filter of Machine.", v => SetFlagState(v, ref isDisabled));
             options.Add("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));
             options.Add("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => SetFlagState(v, ref isTentacleOutdated));

--- a/source/Octopus.Cli/Commands/Package/PackCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PackCommand.cs
@@ -42,7 +42,7 @@ namespace Octopus.Cli.Commands.Package
             common.Add("overwrite", "[Optional] Allow an existing package file of the same ID/version to be overwritten", v => overwrite = true);
 
             var zip = Options.For("Zip packages");
-            zip.Add("compressionlevel=", "[Optional] Set compression level of package: none, fast, optimal (default).", c => compressionLevel = c);
+            zip.Add("compressionLevel=", "[Optional] Set compression level of package: none, fast, optimal (default).", c => compressionLevel = c);
 
             var nuget = Options.For("NuGet packages");
             nuget.Add("author=", "[Optional, Multiple] Add an author to the package metadata; defaults to the current user", v => authors.Add(v));
@@ -55,7 +55,7 @@ namespace Octopus.Cli.Commands.Package
             basic.Add("id=", "The ID of the package; e.g. MyCompany.MyApp", v => id = v);
             basic.Add("format=", "Package format. Options are: NuPkg, Zip. Defaults to NuPkg, though we recommend Zip going forward", fmt => packageBuilder = SelectFormat(fmt));
             basic.Add("version=", "[Optional] The version of the package; must be a valid SemVer; defaults to a timestamp-based version", v => version = string.IsNullOrWhiteSpace(v) ? null : new SemanticVersion(v));
-            basic.Add("outFolder=", "[Optional] The folder into which the generated NUPKG file will be written; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(outFolder)); outFolder = v;});
+            basic.Add("outFolder=", "[Optional] The folder into which the generated NuPkg file will be written; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(outFolder)); outFolder = v;});
             basic.Add("basePath=", "[Optional] The root folder containing files and folders to pack; defaults to '.'", v => { v.CheckForIllegalPathCharacters(nameof(basePath)); basePath = v;});
             basic.Add("verbose", "[Optional] verbose output", v => verbose = true);
             basic.AddLogLevelOptions();

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -32,20 +32,20 @@ namespace Octopus.Cli.Commands.Releases
 
             var options = Options.For("Release creation");
             options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
+            options.Add("defaultPackageVersion=|packageVersion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
             options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
             options.Add("package=", "[Optional] Version number to use for a package in the release. Format: StepName:Version or PackageID:Version or StepName:PackageName:Version. StepName, PackageID, and PackageName can be replaced with an asterisk. An asterisk will be assumed for StepName, PackageID, or PackageName if they are omitted.", v => versionResolver.Add(v));
             options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => {v.CheckForIllegalPathCharacters("packagesFolder"); versionResolver.AddFolder(v);});
-            options.Add("releasenotes=", "[Optional] Release Notes for the new release. Styling with Markdown is supported.", v => ReleaseNotes = v);
-            options.Add("releasenotesfile=", "[Optional] Path to a file that contains Release Notes for the new release. Supports Markdown files.", ReadReleaseNotesFromFile);
-            options.Add("ignoreexisting", "[Optional, Flag] Don't create this release if there is already one with the same version number.", v => IgnoreIfAlreadyExists = true);
-            options.Add("ignorechannelrules", "[Optional, Flag] Create the release ignoring any version rules specified by the channel.", v => IgnoreChannelRules = true);
-            options.Add("packageprerelease=", "[Optional] Pre-release for latest version of all packages to use for this release.", v => VersionPreReleaseTag = v);
-            options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
+            options.Add("releaseNotes=", "[Optional] Release Notes for the new release. Styling with Markdown is supported.", v => ReleaseNotes = v);
+            options.Add("releaseNotesFile=", "[Optional] Path to a file that contains Release Notes for the new release. Supports Markdown files.", ReadReleaseNotesFromFile);
+            options.Add("ignoreExisting", "[Optional, Flag] Don't create this release if there is already one with the same version number.", v => IgnoreIfAlreadyExists = true);
+            options.Add("ignoreChannelRules", "[Optional, Flag] Create the release ignoring any version rules specified by the channel.", v => IgnoreChannelRules = true);
+            options.Add("packagePrerelease=", "[Optional] Pre-release for latest version of all packages to use for this release.", v => VersionPreReleaseTag = v);
+            options.Add("whatIf", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("deployTo=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
         }
 
         public string ChannelNameOrId { get; set; }
@@ -132,14 +132,14 @@ namespace Octopus.Cli.Commands.Releases
 
             if (IgnoreIfAlreadyExists)
             {
-                commandOutputProvider.Debug("Checking for existing release for {Project:l} {Version:l} because you specified --ignoreexisting...", project.Name, versionNumber);
+                commandOutputProvider.Debug("Checking for existing release for {Project:l} {Version:l} because you specified --ignoreExisting...", project.Name, versionNumber);
                 try
                 {
                     var found = await Repository.Projects.GetReleaseByVersion(project, versionNumber)
                         .ConfigureAwait(false);
                     if (found != null)
                     {
-                        commandOutputProvider.Information("A release of {Project:l} with the number {Version:l} already exists, and you specified --ignoreexisting, so we won't even attempt to create the release.", project.Name, versionNumber);
+                        commandOutputProvider.Information("A release of {Project:l} with the number {Version:l} already exists, and you specified --ignoreExisting, so we won't even attempt to create the release.", project.Name, versionNumber);
                         return;
                     }
                 }

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -25,10 +25,10 @@ namespace Octopus.Cli.Commands.Releases
         {
             var options = Options.For("Deletion");
             options.Add("project=", "Name of the project", v => ProjectName = v);
-            options.Add("minversion=", "Minimum (inclusive) version number for the range of versions to delete", v => MinVersion = v);
-            options.Add("maxversion=", "Maximum (inclusive) version number for the range of versions to delete", v => MaxVersion = v);
+            options.Add("minVersion=", "Minimum (inclusive) version number for the range of versions to delete", v => MinVersion = v);
+            options.Add("maxVersion=", "Maximum (inclusive) version number for the range of versions to delete", v => MaxVersion = v);
             options.Add("channel=", "[Optional] if specified, only releases associated with the channel will be deleted; specify this argument multiple times to target multiple channels.", v => ChannelNames.Add(v));
-            options.Add("whatif", "[Optional, Flag] if specified, releases won't actually be deleted, but will be listed as if simulating the command", v => WhatIf = true);
+            options.Add("whatIf", "[Optional, Flag] if specified, releases won't actually be deleted, but will be listed as if simulating the command", v => WhatIf = true);
         }
 
         public string ProjectName { get; set; }
@@ -41,8 +41,8 @@ namespace Octopus.Cli.Commands.Releases
         {
             if (ChannelNames.Any() && !await Repository.SupportsChannels().ConfigureAwait(false)) throw new CommandException("Your Octopus Server does not support channels, which was introduced in Octopus 3.2. Please upgrade your Octopus Server, or remove the --channel arguments.");
             if (string.IsNullOrWhiteSpace(ProjectName)) throw new CommandException("Please specify a project name using the parameter: --project=XYZ");
-            if (string.IsNullOrWhiteSpace(MinVersion)) throw new CommandException("Please specify a minimum version number using the parameter: --minversion=X.Y.Z");
-            if (string.IsNullOrWhiteSpace(MaxVersion)) throw new CommandException("Please specify a maximum version number using the parameter: --maxversion=X.Y.Z");
+            if (string.IsNullOrWhiteSpace(MinVersion)) throw new CommandException("Please specify a minimum version number using the parameter: --minVersion=X.Y.Z");
+            if (string.IsNullOrWhiteSpace(MaxVersion)) throw new CommandException("Please specify a maximum version number using the parameter: --maxVersion=X.Y.Z");
 
             var min = SemanticVersion.Parse(MinVersion);
             var max = SemanticVersion.Parse(MaxVersion);
@@ -71,7 +71,7 @@ namespace Octopus.Cli.Commands.Releases
 
                     if (WhatIf)
                     {
-                        commandOutputProvider.Information("[Whatif] Version {Version:l} would have been deleted", version);
+                        commandOutputProvider.Information("[WhatIf] Version {Version:l} would have been deleted", version);
                         wouldDelete.Add(release);
                     }
                     else

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -23,7 +23,7 @@ namespace Octopus.Cli.Commands.Releases
             var options = Options.For("Release Promotion");
             options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
             options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentNameOrId = v);
-            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add("to=|deployTo=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
             options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
@@ -32,7 +32,7 @@ namespace Octopus.Cli.Commands.Releases
 
         protected override async Task ValidateParameters()
         {
-            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployto=XYZ");
+            if (DeployToEnvironmentNamesOrIds.Count == 0) throw new CommandException("Please specify an environment name or ID using the parameter: --deployTo=XYZ");
             if (string.IsNullOrWhiteSpace(FromEnvironmentNameOrId)) throw new CommandException("Please specify a source environment name or ID using the parameter: --from=XYZ");
 
             await base.ValidateParameters().ConfigureAwait(false);

--- a/source/Octopus.Cli/Commands/WorkerPool/CleanWorkerPoolCommand.cs
+++ b/source/Octopus.Cli/Commands/WorkerPool/CleanWorkerPoolCommand.cs
@@ -28,7 +28,7 @@ namespace Octopus.Cli.Commands.WorkerPool
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("WorkerPool Cleanup");
-            options.Add("workerpool=", "Name of a worker pool to clean up.", v => poolName = v);
+            options.Add("workerPool=", "Name of a worker pool to clean up.", v => poolName = v);
             options.Add("health-status=", $"Health status of Workers to clean up ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
             options.Add("disabled=", "[Optional] Disabled status filter of Worker to clean up.", v => SetFlagState(v, ref isDisabled));
             options.Add("calamari-outdated=", "[Optional] State of Calamari to clean up. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));

--- a/source/Octopus.Cli/Diagnostics/LogExtensions.cs
+++ b/source/Octopus.Cli/Diagnostics/LogExtensions.cs
@@ -128,7 +128,7 @@ namespace Octopus.Cli.Diagnostics
                 }
                 catch (UnauthorizedAccessException uae)
                 {
-                    throw new UnauthorizedAccessException($"Could not write the TFS service message file '{markdownFile}'. Please make sure the SYSTEM_DEFAULTWORKINGDIRECTORY environment variable is set to a writeable directory. If this command is not being run on a build agent, ommit the --enableservicemessages parameter.", uae);
+                    throw new UnauthorizedAccessException($"Could not write the TFS service message file '{markdownFile}'. Please make sure the SYSTEM_DEFAULTWORKINGDIRECTORY environment variable is set to a writeable directory. If this command is not being run on a build agent, omit the --enableServiceMessages parameter.", uae);
                 }
 
                 log.Information("##vso[task.addattachment type=Distributedtask.Core.Summary;name=Octopus Deploy;]{MarkdownFile:l}", markdownFile);

--- a/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
+++ b/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
@@ -100,7 +100,7 @@ namespace Octopus.Cli.Repositories
             if (!await repository.SupportsTenants().ConfigureAwait(false))
             {
                 throw new CommandException(
-                    "Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenanttag arguments.");
+                    "Your Octopus Server does not support tenants, which was introduced in Octopus 3.4. Please upgrade your Octopus Server, enable the multi-tenancy feature or remove the --tenant and --tenantTag arguments.");
             }
 
             var tenantsByName = FindTenantsByName(tenantNames).ConfigureAwait(false);


### PR DESCRIPTION
Part of the work to auto-generate the specification required for nuke build.
See https://github.com/nuke-build/nuke/blob/develop/build/specifications/Octopus.json