### PR TITLE
Make `install-autocomplete` and `complete` support `--help` argument

### DIFF
--- a/source/Octo.Tests/Commands/CompleteCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CompleteCommandFixture.cs
@@ -100,6 +100,17 @@ namespace Octo.Tests.Commands
                 .Contain("--url");
         }
 
+        [Test]
+        [TestCase("--help")]
+        [TestCase("foo --help")]
+        public async Task SupportsHelpOption(string commandLine)
+        {
+            await completeCommand.Execute(commandLine.Split(' '));
+            output.ToString()
+                .Should()
+                .Contain("Where <command> is the current command line to filter auto-completions");
+        }
+
         [TearDown]
         public void TearDown()
         {
@@ -108,7 +119,7 @@ namespace Octo.Tests.Commands
     }
 
     [Command("test", Description = "test command")]
-    public class TestCommand : CommandBase, ICommand
+    public class TestCommand : CommandBase
     {
         public TestCommand(ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)
         {
@@ -120,7 +131,7 @@ namespace Octo.Tests.Commands
         public string Url { get; set; }
 
         public string ApiKey { get; set; }
-        public Task Execute(string[] commandLineArguments)
+        public override Task Execute(string[] commandLineArguments)
         {
             return Task.Run(() => 0);
         }

--- a/source/Octo.Tests/Commands/InstallAutoCompleteFixture.cs
+++ b/source/Octo.Tests/Commands/InstallAutoCompleteFixture.cs
@@ -72,6 +72,13 @@ namespace Octo.Tests.Commands
         }
         
         [Test]
+        public async Task SupportsHelpOption()
+        {
+            await installAutoCompleteCommand.Execute(new[] {"--help"});
+            commandOutputProvider.Received().PrintCommandHelpHeader(Arg.Any<string>(), "install-autocomplete", Arg.Any<string>(), Arg.Any<TextWriter>());
+        }
+        
+        [Test]
         public async Task ShouldPreventInstallationOfPowershellOnLinux()
         {
             if (ExecutionEnvironment.IsRunningOnNix || ExecutionEnvironment.IsRunningOnMac)

--- a/source/Octo.Tests/Commands/SpeakCommand.cs
+++ b/source/Octo.Tests/Commands/SpeakCommand.cs
@@ -6,7 +6,7 @@ using Octopus.Cli.Util;
 
 namespace Octo.Tests.Commands
 {
-    public class SpeakCommand : CommandBase, ICommand
+    public class SpeakCommand : CommandBase
     {
         //public OptionSet Options
         //{
@@ -27,7 +27,7 @@ namespace Octo.Tests.Commands
         //    commandOutputProvider.PrintCommandHelpFooter("executable", "speak", writer);
         //}
 
-        public Task Execute(string[] commandLineArguments)
+        public override Task Execute(string[] commandLineArguments)
         {
             return Task.Run(() => Assert.Fail("This should not be called"));
         }

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -19,7 +19,7 @@ using Serilog.Events;
 
 namespace Octopus.Cli.Commands
 {
-    public abstract class ApiCommand : CommandBase, ICommand
+    public abstract class ApiCommand : CommandBase
     {
         /// <summary>
         /// The environment variable that can hold the Octopus Server
@@ -115,7 +115,7 @@ namespace Octopus.Cli.Commands
 
         protected IOctopusFileSystem FileSystem { get; }
 
-        public async Task Execute(string[] commandLineArguments)
+        public override async Task Execute(string[] commandLineArguments)
         {
             var remainingArguments = Options.Parse(commandLineArguments);
 

--- a/source/Octopus.Cli/Commands/CommandBase.cs
+++ b/source/Octopus.Cli/Commands/CommandBase.cs
@@ -2,13 +2,14 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Model;
 using Octopus.Cli.Util;
 
 namespace Octopus.Cli.Commands
 {
-    public abstract class CommandBase
+    public abstract class CommandBase : ICommand
     {
         protected readonly ICommandOutputProvider commandOutputProvider;
         protected bool printHelp;
@@ -68,6 +69,8 @@ namespace Octopus.Cli.Commands
             }
         }
 
+        public abstract Task Execute(string[] commandLineArguments);
+
         private void SetOutputFormat(string s)
         {
             OutputFormat = ParseOutputFormat(s);
@@ -84,7 +87,7 @@ namespace Octopus.Cli.Commands
             return Enum.TryParse(s, true, out outputFormat) ? outputFormat : OutputFormat.Default;
         }
 
-        private void PrintDefaultHelpOutput(TextWriter writer, string executable, string commandName, string description)
+        protected virtual void PrintDefaultHelpOutput(TextWriter writer, string executable, string commandName, string description)
         {
             commandOutputProvider.PrintCommandHelpHeader(executable, commandName, description, writer);
             commandOutputProvider.PrintCommandOptions(Options, writer);

--- a/source/Octopus.Cli/Commands/HelpCommand.cs
+++ b/source/Octopus.Cli/Commands/HelpCommand.cs
@@ -8,7 +8,7 @@ using Octopus.Cli.Util;
 namespace Octopus.Cli.Commands
 {
     [Command("help", "?", "h", Description = "Prints this help text.")]
-    public class HelpCommand : CommandBase, ICommand
+    public class HelpCommand : CommandBase
     {
         readonly ICommandLocator commands;
         string executable;
@@ -18,7 +18,7 @@ namespace Octopus.Cli.Commands
             this.commands = commands;
         }
 
-        public Task Execute(string[] commandLineArguments)
+        public override Task Execute(string[] commandLineArguments)
         {
             return Task.Run(() =>
             {

--- a/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
+++ b/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
@@ -18,7 +18,7 @@ namespace Octopus.Cli.Commands
     }
     
     [Command(name: "install-autocomplete", Description = "Install a shell auto-complete script into your shell profile, if they aren't already there. Supports pwsh, zsh, bash & powershell.")]
-    public class InstallAutoCompleteCommand : CommandBase, ICommand
+    public class InstallAutoCompleteCommand : CommandBase
     {
         private readonly IEnumerable<ShellCompletionInstaller> installers;
 
@@ -50,10 +50,16 @@ namespace Octopus.Cli.Commands
 
         public SupportedShell ShellSelection { get; set; }
 
-        public Task Execute(string[] commandLineArguments)
+        public override Task Execute(string[] commandLineArguments)
         {
-            var invalidShellSelectionMessage = $"Please specify the type of shell to install autocompletion for: --shell=XYZ. Valid values are {supportedShells}.";
             Options.Parse(commandLineArguments);
+            if (printHelp)
+            {
+                GetHelp(Console.Out, commandLineArguments);
+                return Task.FromResult(0);
+            }
+            
+            var invalidShellSelectionMessage = $"Please specify the type of shell to install auto-completion for: --shell=XYZ. Valid values are {supportedShells}.";
             if (ShellSelection == SupportedShell.Unspecified) throw new CommandException(invalidShellSelectionMessage);
 
 

--- a/source/Octopus.Cli/Commands/Package/PackCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PackCommand.cs
@@ -15,7 +15,7 @@ using SemanticVersion = Octopus.Client.Model.SemanticVersion;
 namespace Octopus.Cli.Commands.Package
 {
     [Command("pack", Description = "Creates a package (.nupkg or .zip) from files on disk, without needing a .nuspec or .csproj.")]
-    public class PackCommand : CommandBase, ICommand, ISupportFormattedOutput
+    public class PackCommand : CommandBase, ISupportFormattedOutput
     {
         readonly IList<string> authors = new List<string>();
         readonly IOctopusFileSystem fileSystem;
@@ -63,7 +63,7 @@ namespace Octopus.Cli.Commands.Package
             packageBuilder = SelectFormat("nupkg");
         }
 
-       public Task Execute(string[] commandLineArguments)
+       public override Task Execute(string[] commandLineArguments)
         {
             return Task.Run(() =>
             {

--- a/source/Octopus.Cli/Commands/VersionCommand.cs
+++ b/source/Octopus.Cli/Commands/VersionCommand.cs
@@ -6,13 +6,13 @@ using Octopus.Cli.Util;
 namespace Octopus.Cli.Commands
 {
     [Command("version", "v", "ver", Description = "Outputs Octopus CLI version.")]
-    public class VersionCommand : CommandBase, ICommand
+    public class VersionCommand : CommandBase
     {
         public VersionCommand(ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)
         {
         }
 
-        public Task Execute(string[] commandLineArgs)
+        public override Task Execute(string[] commandLineArgs)
         {
             return Task.Run(() =>
             {


### PR DESCRIPTION
This is used for auto-generation of docs

Fixes #63

## Before

### `install-autocomplete`

```
PS > .\octo.exe --install-autocomplete --help
Please specify the type of shell to install auto-completion for: --shell=XYZ. Valid values are Pwsh, Zsh, Bash and Powershell.
Exit code: -1
```

### `complete`

```
PS > .\octo.exe complete --help
--help
--helpOutputFormat
```

## After

### `install-autocomplete`

```
PS > .\octo.exe --install-autocomplete --help
Install a shell auto-complete script into your shell profile, if they aren't already there. Supports pwsh, zsh, bash & powershell.

Usage: octo install-autocomplete [<options>]

Where [<options>] is any of:

Install AutoComplete:

      --shell=VALUE          The type of shell to install auto-complete
                             scripts for. This will alter your shell
                             configuration files. Supported shells are Pwsh,
                             Zsh, Bash and Powershell.
      --dryRun               [Optional] Dry run will output the proposed
                             changes to console, instead of writing to disk.

Common options:

      --help                 [Optional] Print help for a command
      --helpOutputFormat=VALUE
                             [Optional] Output format for help, only valid
                             option is json
```

### `complete`

```
PS > .\octo.exe complete --help
Supports command line auto completion.

Usage: octo complete <command> [<options>]

Where <command> is the current command line to filter auto-completions.

Where [<options>] is any of:

Common options:

      --help                 [Optional] Print help for a command
      --helpOutputFormat=VALUE
                             [Optional] Output format for help, only valid
                             option is json
```