### PR TITLE
Typed options

### DIFF
--- a/source/Octo.Tests/Commands/CompleteCommandFixture.cs
+++ b/source/Octo.Tests/Commands/CompleteCommandFixture.cs
@@ -113,8 +113,8 @@ namespace Octo.Tests.Commands
         public TestCommand(ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)
         {
             var options = Options.For("Test group");
-            options.Add("apiKey", "api key", v => ApiKey = v);
-            options.Add("url", "url", v => Url = v);
+            options.Add<string>("apiKey", "api key", v => ApiKey = v);
+            options.Add<string>("url", "url", v => Url = v);
         }
 
         public string Url { get; set; }

--- a/source/Octo.Tests/Commands/DummyApiCommand.cs
+++ b/source/Octo.Tests/Commands/DummyApiCommand.cs
@@ -14,7 +14,7 @@ namespace Octo.Tests.Commands
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Dummy");
-            options.Add("pill=", "Red or Blue. Blue, the story ends. Red, stay in Wonderland and see how deep the rabbit hole goes.", v => pill = v);
+            options.Add<string>("pill=", "Red or Blue. Blue, the story ends. Red, stay in Wonderland and see how deep the rabbit hole goes.", v => pill = v);
             commandOutputProvider.Debug("Pill: " + pill);
         }
 

--- a/source/Octo.Tests/Commands/ListMachinesCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ListMachinesCommandFixture.cs
@@ -315,7 +315,7 @@ namespace Octo.Tests.Commands
         [Test]
         public async Task ShouldThrowIfUsingHealthStatusPre34()
         {
-            CommandLineArgs.Add("--health-status=Online");
+            CommandLineArgs.Add("--health-status=Healthy");
             (await Repository.LoadRootDocument()).Version = "3.1.0";
 
             Func<Task> exec = () => listMachinesCommand.Execute(CommandLineArgs.ToArray());

--- a/source/Octo.Tests/Commands/OptionsFixture.cs
+++ b/source/Octo.Tests/Commands/OptionsFixture.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+using Octopus.Cli.Commands.Package;
 using Octopus.Cli.Infrastructure;
 
 namespace Octo.Tests.Commands
@@ -16,17 +18,25 @@ namespace Octo.Tests.Commands
         {
             var apiKey = string.Empty;
             var foo = string.Empty;
-            
-            var optionSet = new OptionSet()
-            {
-                {"apiKey=", "API key", v => apiKey = v},
-                {"foo=", "Foo", v => foo = v}
-            };
+
+            var optionSet = new OptionSet();
+            optionSet.Add<string>("apiKey=", "API key", v => apiKey = v);
+            optionSet.Add<string>("foo=", "Foo", v => foo = v);
 
             optionSet.Parse(new[] {parameter1, parameter2});
 
             Assert.That(apiKey, Is.EqualTo("abc123"));
             Assert.That(foo, Is.EqualTo("bar"));
+        }
+
+        [Test]
+        public void ShowsValidValuesForEnums()
+        {
+            var optionSet = new OptionSet();
+            optionSet.Add<PackageFormat>("packageFormat=", "Package Format", v => { });
+
+            var ex = Assert.Throws<CommandException>(() => optionSet.Parse(new[] {"--packageFormat", "invalidvalue"}));
+            Assert.That(ex.Message, Is.EqualTo("Could not convert string `invalidvalue' to type PackageFormat for option `--packageFormat'. Valid values are Zip, Nupkg and Nuget."));
         }
     }
 }

--- a/source/Octo.Tests/Commands/SpeakCommand.cs
+++ b/source/Octo.Tests/Commands/SpeakCommand.cs
@@ -35,7 +35,7 @@ namespace Octo.Tests.Commands
         public SpeakCommand(ICommandOutputProvider commandOutputProvider) : base(commandOutputProvider)
         {
             var options = Options.For("default");
-            options.Add("message=", m => { });
+            options.Add<string>("message=", m => { });
         }
     }
 }

--- a/source/Octo.Tests/Commands/SupportFormattedOutputFixture.cs
+++ b/source/Octo.Tests/Commands/SupportFormattedOutputFixture.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using Octopus.Cli.Infrastructure;
 
 namespace Octo.Tests.Commands
 {
@@ -35,15 +36,16 @@ namespace Octo.Tests.Commands
         }
         
         [Test]
-        public async Task FormattedOutput_FormatInvalid()
+        public void FormattedOutput_FormatInvalid()
         {
             var command = new DummyApiCommandWithFormattedOutputSupport(ClientFactory, RepositoryFactory, FileSystem, CommandOutputProvider);
             CommandLineArgs.Add("--helpOutputFormat=blah");
 
-            await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false);
+            var exception = Assert.ThrowsAsync<CommandException>(async () => await command.Execute(CommandLineArgs.ToArray()).ConfigureAwait(false));
 
-            command.PrintJsonOutputCalled.ShouldBeEquivalentTo(false);
-            command.PrintDefaultOutputCalled.ShouldBeEquivalentTo(true);
+            command.PrintJsonOutputCalled.Should().BeFalse();
+            command.PrintDefaultOutputCalled.Should().BeFalse();
+            exception.Message.Should().Be("Could not convert string `blah' to type OutputFormat for option `--helpOutputFormat'. Valid values are Default and Json.");
         }
 
         [Test]

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -79,8 +79,8 @@ namespace Octopus.Cli.Commands
             });
             options.Add<string>("proxy=", $"[Optional] The URL of the proxy to use, e.g., 'https://proxy.example.com'.", v => clientOptions.Proxy = v);
             options.Add<string>("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
-            options.Add<string>("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v, sensitive: true);
-            options.Add<string>("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);
+            options.Add<string>("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used.", v => clientOptions.ProxyPassword = v, sensitive: true);
+            options.Add<string>("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted.", v => spaceNameOrId = v);
 #if NETFRAMEWORK
             options.Add<int>("keepalive=", "[Optional] How frequently (in seconds) to send a TCP keepalive packet.", input => keepAlive = input * 1000);
 #endif

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -59,16 +59,16 @@ namespace Octopus.Cli.Commands
             this.FileSystem = fileSystem;
 
             var options = Options.For("Common options");
-            options.Add("server=", $"[Optional] The base URL for your Octopus Server, e.g., 'https://octopus.example.com/'. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
-            options.Add("apiKey=", $"[Optional] Your API key. Get this from the user profile page. Your must provide an apiKey or username and password. If the guest account is enabled, a key of API-GUEST can be used. This key can also be set in the {ApiKeyEnvVar} environment variable.", v => apiKey = v);
-            options.Add("user=", $"[Optional] Username to use when authenticating with the server. Your must provide an apiKey or username and password. This Username can also be set in the {UsernameEnvVar} environment variable.", v => username = v);
-            options.Add("pass=", $"[Optional] Password to use when authenticating with the server. This Password can also be set in the {PasswordEnvVar} environment variable.", v => password = v);
+            options.Add<string>("server=", $"[Optional] The base URL for your Octopus Server, e.g., 'https://octopus.example.com/'. This URL can also be set in the {ServerUrlEnvVar} environment variable.", v => serverBaseUrl = v);
+            options.Add<string>("apiKey=", $"[Optional] Your API key. Get this from the user profile page. Your must provide an apiKey or username and password. If the guest account is enabled, a key of API-GUEST can be used. This key can also be set in the {ApiKeyEnvVar} environment variable.", v => apiKey = v, sensitive: true);
+            options.Add<string>("user=", $"[Optional] Username to use when authenticating with the server. Your must provide an apiKey or username and password. This Username can also be set in the {UsernameEnvVar} environment variable.", v => username = v);
+            options.Add<string>("pass=", $"[Optional] Password to use when authenticating with the server. This Password can also be set in the {PasswordEnvVar} environment variable.", v => password = v, sensitive: true);
 
-            options.Add("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(v));
-            options.Add("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
-            options.Add("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
-            options.Add("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
-            options.Add("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v =>
+            options.Add<string>("configFile=", "[Optional] Text file of default values, with one 'key = value' per line.", v => ReadAdditionalInputsFromConfigurationFile(v));
+            options.Add<bool>("debug", "[Optional] Enable debug logging", v => enableDebugging = true);
+            options.Add<bool>("ignoreSslErrors", "[Optional] Set this flag if your Octopus Server uses HTTPS but the certificate is not trusted on this machine. Any certificate errors will be ignored. WARNING: this option may create a security vulnerability.", v => ignoreSslErrors = true);
+            options.Add<bool>("enableServiceMessages", "[Optional] Enable TeamCity or Team Foundation Build service messages when logging.", v => commandOutputProvider.EnableServiceMessages());
+            options.Add<string>("timeout=", $"[Optional] Timeout in seconds for network operations. Default is {ApiConstants.DefaultClientRequestTimeout/1000}.", v =>
             {
                 if (int.TryParse(v, out var parsedInt))
                     clientOptions.Timeout = TimeSpan.FromSeconds(parsedInt);
@@ -77,18 +77,12 @@ namespace Octopus.Cli.Commands
                 else
                     throw new CommandException($"Unable to parse '{v}' as a timespan or an integer.");
             });
-            options.Add("proxy=", $"[Optional] The URL of the proxy to use, e.g., 'https://proxy.example.com'.", v => clientOptions.Proxy = v);
-            options.Add("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
-            options.Add("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v);
-            options.Add("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);
+            options.Add<string>("proxy=", $"[Optional] The URL of the proxy to use, e.g., 'https://proxy.example.com'.", v => clientOptions.Proxy = v);
+            options.Add<string>("proxyUser=", $"[Optional] The username for the proxy.", v => clientOptions.ProxyUsername = v);
+            options.Add<string>("proxyPass=", $"[Optional] The password for the proxy. If both the username and password are omitted and proxyAddress is specified, the default credentials are used. ", v => clientOptions.ProxyPassword = v, sensitive: true);
+            options.Add<string>("space=", $"[Optional] The name or ID of a space within which this command will be executed. The default space will be used if it is omitted. ", v => spaceNameOrId = v);
 #if NETFRAMEWORK
-            options.Add("keepalive=", "[Optional] How frequently (in seconds) to send a TCP keepalive packet.", input =>
-            {
-                if (int.TryParse(input, out var parsedInt))
-                    keepAlive = parsedInt * 1000;
-                else
-                    throw new CommandException($"Unable to parse '{input}' as an integer.");
-            });
+            options.Add<int>("keepalive=", "[Optional] How frequently (in seconds) to send a TCP keepalive packet.", input => keepAlive = input * 1000);
 #endif
             options.AddLogLevelOptions();
         }

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -269,32 +269,6 @@ namespace Octopus.Cli.Commands
             }
         }
 
-        static NetworkCredential ParseCredentials(string username, string password)
-        {
-            if (string.IsNullOrWhiteSpace(username))
-                return CredentialCache.DefaultNetworkCredentials;
-
-            var split = username.Split('\\');
-            if (split.Length == 2)
-            {
-                var domain = split.First();
-                username = split.Last();
-
-                return new NetworkCredential(username, password, domain);
-            }
-
-            return new NetworkCredential(username, password);
-        }
-
-        protected void SetFlagState(string input, ref bool? setter)
-        {
-            bool tempBool;
-            if (bool.TryParse(input, out tempBool))
-            {
-                setter = tempBool;
-            }
-        }
-
         protected List<string> ReadAdditionalInputsFromConfigurationFile(string configFile)
         {
             configFile = FileSystem.GetFullPath(configFile);

--- a/source/Octopus.Cli/Commands/Channel/CreateChannelCommand.cs
+++ b/source/Octopus.Cli/Commands/Channel/CreateChannelCommand.cs
@@ -17,12 +17,12 @@ namespace Octopus.Cli.Commands.Channel
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Create");
-            options.Add("project=", "The name of the project in which to create the channel", p => projectName = p);
-            options.Add("channel=", "The name of the channel to create", s => channelName = s);
-            options.Add("description=", "[Optional] A description of the channel", d => channelDescription = d);
-            options.Add("lifecycle=", "[Optional] if specified, the name of the lifecycle to use for promoting releases through this channel, otherwise this channel will inherit the project lifecycle", l => lifecycleName = l);
-            options.Add("make-default-channel", "[Optional, Flag] if specified, set the new channel to be the default channel replacing any existing default channel", _ => makeDefaultChannel = true);
-            options.Add("update-existing", "[Optional, Flag] if specified, updates the matching channel if it already exists, otherwise this command will fail if a matching channel already exists", _ => updateExisting = true);
+            options.Add<string>("project=", "The name of the project in which to create the channel", p => projectName = p);
+            options.Add<string>("channel=", "The name of the channel to create", s => channelName = s);
+            options.Add<string>("description=", "[Optional] A description of the channel", d => channelDescription = d);
+            options.Add<string>("lifecycle=", "[Optional] if specified, the name of the lifecycle to use for promoting releases through this channel, otherwise this channel will inherit the project lifecycle", l => lifecycleName = l);
+            options.Add<bool>("make-default-channel", "[Optional, Flag] if specified, set the new channel to be the default channel replacing any existing default channel", _ => makeDefaultChannel = true);
+            options.Add<bool>("update-existing", "[Optional, Flag] if specified, updates the matching channel if it already exists, otherwise this command will fail if a matching channel already exists", _ => updateExisting = true);
         }
 
         string channelName;

--- a/source/Octopus.Cli/Commands/Deployment/CreateAutoDeployOverrideCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/CreateAutoDeployOverrideCommand.cs
@@ -26,16 +26,16 @@ namespace Octopus.Cli.Commands.Deployment
             base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Auto deploy release override");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
-            options.Add("environment=",
+            options.Add<string>("project=", "Name of the project", v => ProjectName = v);
+            options.Add<string>("environment=",
                 "Name of an environment the override will apply to. Specify this argument multiple times to add multiple environments.",
                 v => EnvironmentNames.Add(v));
-            options.Add("version=|releaseNumber=", "Release number to use for auto deployments.",
+            options.Add<string>("version=|releaseNumber=", "Release number to use for auto deployments.",
                 v => ReleaseVersionNumber = v);
-            options.Add("tenant=",
+            options.Add<string>("tenant=",
                 "[Optional] Name of a tenant the override will apply to. Specify this argument multiple times to add multiple tenants or use `*` wildcard for all tenants.",
                 t => TenantNames.Add(t));
-            options.Add("tenanttag=",
+            options.Add<string>("tenanttag=",
                 "[Optional] A tenant tag used to match tenants that the override will apply to. Specify this argument multiple times to add multiple tenant tags",
                 tt => TenantTags.Add(tt));
 

--- a/source/Octopus.Cli/Commands/Deployment/DeleteAutoDeployOverrideCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeleteAutoDeployOverrideCommand.cs
@@ -22,14 +22,14 @@ namespace Octopus.Cli.Commands.Deployment
             base(octopusClientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Delete auto deploy release override");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
-            options.Add("environment=",
+            options.Add<string>("project=", "Name of the project", v => ProjectName = v);
+            options.Add<string>("environment=",
                 "Name of an environment the override will apply to. Specify this argument multiple times to add multiple environments.",
                 v => EnvironmentNames.Add(v));
-            options.Add("tenant=",
+            options.Add<string>("tenant=",
                 "[Optional] Name of a tenant the override will apply to. Specify this argument multiple times to add multiple tenants or use `*` wildcard for all tenants.",
                 t => TenantNames.Add(t));
-            options.Add("tenanttag=",
+            options.Add<string>("tenanttag=",
                 "[Optional] A tenant tag used to match tenants that the override will apply to. Specify this argument multiple times to add multiple tenant tags",
                 tt => TenantTags.Add(tt));
 

--- a/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeployReleaseCommand.cs
@@ -21,11 +21,11 @@ namespace Octopus.Cli.Commands.Deployment
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Deployment");
-            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
-            options.Add("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
-            options.Add("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelNameOrId = v);
-            options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
+            options.Add<string>("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add<string>("deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add<string>("releaseNumber=|version=", "Version number of the release to deploy. Or specify --version=latest for the latest release.", v => VersionNumber = v);
+            options.Add<string>("channel=", "[Optional] Name or ID of the channel to use when getting the release to deploy", v => ChannelNameOrId = v);
+            options.Add<bool>("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
         public string VersionNumber { get; set; }

--- a/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
+++ b/source/Octopus.Cli/Commands/Deployment/DeploymentCommandBase.cs
@@ -34,24 +34,24 @@ namespace Octopus.Cli.Commands.Deployment
             promotionTargets = new List<DeploymentPromotionTarget>();
 
             var options = Options.For("Deployment");
-            options.Add("progress", "[Optional] Show progress of the deployment", v => { showProgress = true; WaitForDeployment = true; noRawLog = true; });
-            options.Add("forcepackagedownload", "[Optional] Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
-            options.Add("waitfordeployment", "[Optional] Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
-            options.Add("deploymenttimeout=", "[Optional] Specifies maximum time (timespan format) that the console session will wait for the deployment to finish(default 00:10:00). This will not stop the deployment. Requires --waitfordeployment parameter set.", v => DeploymentTimeout = TimeSpan.Parse(v));
-            options.Add("cancelontimeout", "[Optional] Whether to cancel the deployment if the deployment timeout is reached (flag, default false).", v => CancelOnTimeout = true);
-            options.Add("deploymentchecksleepcycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = TimeSpan.Parse(v));
-            options.Add("guidedfailure=", "[Optional] Whether to use guided failure mode. (True or False. If not specified, will use default setting from environment)", v => UseGuidedFailure = bool.Parse(v));
-            options.Add("specificmachines=", "[Optional] A comma-separated list of machine names to target in the deployed environment. If not specified all machines in the environment will be considered.", v => SpecificMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
-            options.Add("excludemachines=", "[Optional] A comma-separated list of machine names to exclude in the deployed environment. If not specified all machines in the environment will be considered.", v => ExcludedMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
-            options.Add("force", "[Optional] If a project is configured to skip packages with already-installed versions, override this setting to force re-deployment (flag, default false).", v => ForcePackageRedeployment = true);
-            options.Add("skip=", "[Optional] Skip a step by name", v => SkipStepNames.Add(v));
-            options.Add("norawlog", "[Optional] Don't print the raw log of failed tasks", v => noRawLog = true);
-            options.Add("rawlogfile=", "[Optional] Redirect the raw log of failed tasks to a file", v => rawLogFile = v);
-            options.Add("v|variable=", "[Optional] Values for any prompted variables in the format Label:Value. For JSON values, embedded quotation marks should be escaped with a backslash.", ParseVariable);
-            options.Add("deployat=", "[Optional] Time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => DeployAt = ParseDateTimeOffset(v));
-            options.Add("nodeployafter=", "[Optional] Time at which scheduled deployment should expire, specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => NoDeployAfter = ParseDateTimeOffset(v));
-            options.Add("tenant=", "Create a deployment for the tenant with this name or ID; specify this argument multiple times to add multiple tenants or use `*` wildcard to deploy to all tenants who are ready for this release (according to lifecycle).", t => Tenants.Add(t));
-            options.Add("tenanttag=", "Create a deployment for tenants matching this tag; specify this argument multiple times to build a query/filter with multiple tags, just like you can in the user interface.", tt => TenantTags.Add(tt));
+            options.Add<bool>("progress", "[Optional] Show progress of the deployment", v => { showProgress = true; WaitForDeployment = true; noRawLog = true; });
+            options.Add<bool>("forcepackagedownload", "[Optional] Whether to force downloading of already installed packages (flag, default false).", v => ForcePackageDownload = true);
+            options.Add<bool>("waitfordeployment", "[Optional] Whether to wait synchronously for deployment to finish.", v => WaitForDeployment = true);
+            options.Add<TimeSpan>("deploymenttimeout=", "[Optional] Specifies maximum time (timespan format) that the console session will wait for the deployment to finish(default 00:10:00). This will not stop the deployment. Requires --waitfordeployment parameter set.", v => DeploymentTimeout = v);
+            options.Add<bool>("cancelontimeout", "[Optional] Whether to cancel the deployment if the deployment timeout is reached (flag, default false).", v => CancelOnTimeout = true);
+            options.Add<TimeSpan>("deploymentchecksleepcycle=", "[Optional] Specifies how much time (timespan format) should elapse between deployment status checks (default 00:00:10)", v => DeploymentStatusCheckSleepCycle = v);
+            options.Add<bool>("guidedfailure=", "[Optional] Whether to use guided failure mode. (True or False. If not specified, will use default setting from environment)", v => UseGuidedFailure = v);
+            options.Add<string>("specificmachines=", "[Optional] A comma-separated list of machine names to target in the deployed environment. If not specified all machines in the environment will be considered.", v => SpecificMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
+            options.Add<string>("excludemachines=", "[Optional] A comma-separated list of machine names to exclude in the deployed environment. If not specified all machines in the environment will be considered.", v => ExcludedMachineNames.AddRange(v.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(m => m.Trim())));
+            options.Add<bool>("force", "[Optional] If a project is configured to skip packages with already-installed versions, override this setting to force re-deployment (flag, default false).", v => ForcePackageRedeployment = true);
+            options.Add<string>("skip=", "[Optional] Skip a step by name", v => SkipStepNames.Add(v));
+            options.Add<bool>("norawlog", "[Optional] Don't print the raw log of failed tasks", v => noRawLog = true);
+            options.Add<string>("rawlogfile=", "[Optional] Redirect the raw log of failed tasks to a file", v => rawLogFile = v);
+            options.Add<string>("v|variable=", "[Optional] Values for any prompted variables in the format Label:Value. For JSON values, embedded quotation marks should be escaped with a backslash.", ParseVariable);
+            options.Add<DateTimeOffset>("deployat=", "[Optional] Time at which deployment should start (scheduled deployment), specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => DeployAt = v);
+            options.Add<DateTimeOffset>("nodeployafter=", "[Optional] Time at which scheduled deployment should expire, specified as any valid DateTimeOffset format, and assuming the time zone is the current local time zone.", v => NoDeployAfter = v);
+            options.Add<string>("tenant=", "Create a deployment for the tenant with this name or ID; specify this argument multiple times to add multiple tenants or use `*` wildcard to deploy to all tenants who are ready for this release (according to lifecycle).", t => Tenants.Add(t));
+            options.Add<string>("tenanttag=", "Create a deployment for tenants matching this tag; specify this argument multiple times to build a query/filter with multiple tags, just like you can in the user interface.", tt => TenantTags.Add(tt));
         }
 
         protected bool ForcePackageRedeployment { get; set; }

--- a/source/Octopus.Cli/Commands/Deployment/ListDeploymentsCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/ListDeploymentsCommand.cs
@@ -32,10 +32,10 @@ namespace Octopus.Cli.Commands.Deployment
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing");
-            options.Add("project=", "[Optional] Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
-            options.Add("environment=", "[Optional] Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
-            options.Add("tenant=", "[Optional] Name of a tenant to filter by. Can be specified many times.", v => tenants.Add(v));
-            options.Add("number=", $"[Optional] number of results to return, default is {DefaultReturnAmount}", v => numberOfResults = int.Parse(v));
+            options.Add<string>("project=", "[Optional] Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
+            options.Add<string>("environment=", "[Optional] Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
+            options.Add<string>("tenant=", "[Optional] Name of a tenant to filter by. Can be specified many times.", v => tenants.Add(v));
+            options.Add<int>("number=", $"[Optional] number of results to return, default is {DefaultReturnAmount}", v => numberOfResults = v);
         }
 
         public async Task Request()

--- a/source/Octopus.Cli/Commands/Deployment/ListLatestDeploymentsCommand.cs
+++ b/source/Octopus.Cli/Commands/Deployment/ListLatestDeploymentsCommand.cs
@@ -29,8 +29,8 @@ namespace Octopus.Cli.Commands.Deployment
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing");
-            options.Add("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
-            options.Add("environment=", "Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
+            options.Add<string>("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
+            options.Add<string>("environment=", "Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
         }
 
         private async Task<IDictionary<string, string>> LoadProjects()

--- a/source/Octopus.Cli/Commands/Environment/CreateEnvironmentCommand.cs
+++ b/source/Octopus.Cli/Commands/Environment/CreateEnvironmentCommand.cs
@@ -17,8 +17,8 @@ namespace Octopus.Cli.Commands.Environment
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Environment creation");
-            options.Add("name=", "The name of the environment", v => EnvironmentName = v);
-            options.Add("ignoreIfExists", "If the environment already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
+            options.Add<string>("name=", "The name of the environment", v => EnvironmentName = v);
+            options.Add<bool>("ignoreIfExists", "If the environment already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
         }
 
         public string EnvironmentName { get; set; }

--- a/source/Octopus.Cli/Commands/ExportCommand.cs
+++ b/source/Octopus.Cli/Commands/ExportCommand.cs
@@ -19,11 +19,11 @@ namespace Octopus.Cli.Commands
             this.exporterLocator = exporterLocator;
 
             var options = Options.For("Export");
-            options.Add("type=", "The type to export", v => Type = v);
-            options.Add("filePath=", "The full path and name of the export file", v => FilePath = v);
-            options.Add("project=", "[Optional] Name of the project", v => Project = v);
-            options.Add("name=", "[Optional] Name of the item to export", v => Name = v);
-            options.Add("releaseVersion=", "[Optional] The version number, or range of version numbers to export", v => ReleaseVersion = v);
+            options.Add<string>("type=", "The type to export", v => Type = v);
+            options.Add<string>("filePath=", "The full path and name of the export file", v => FilePath = v);
+            options.Add<string>("project=", "[Optional] Name of the project", v => Project = v);
+            options.Add<string>("name=", "[Optional] Name of the item to export", v => Name = v);
+            options.Add<string>("releaseVersion=", "[Optional] The version number, or range of version numbers to export", v => ReleaseVersion = v);
         }
 
         public string Type { get; set; }

--- a/source/Octopus.Cli/Commands/ImportCommand.cs
+++ b/source/Octopus.Cli/Commands/ImportCommand.cs
@@ -19,10 +19,10 @@ namespace Octopus.Cli.Commands
             this.importerLocator = importerLocator;
 
             var options = Options.For("Import");
-            options.Add("type=", "The Octopus object type to import", v => Type = v);
-            options.Add("filePath=", "The full path and name of the exported file", v => FilePath = v);
-            options.Add("project=", "[Optional] The name of the project", v => Project = v);
-            options.Add("dryRun", "[Optional] Perform a dry run of the import", v => DryRun = true);
+            options.Add<string>("type=", "The Octopus object type to import", v => Type = v);
+            options.Add<string>("filePath=", "The full path and name of the exported file", v => FilePath = v);
+            options.Add<string>("project=", "[Optional] The name of the project", v => Project = v);
+            options.Add<bool>("dryRun", "[Optional] Perform a dry run of the import", v => DryRun = true);
         }
 
         public bool DryRun { get; set; }

--- a/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
+++ b/source/Octopus.Cli/Commands/InstallAutoCompleteCommand.cs
@@ -32,16 +32,10 @@ namespace Octopus.Cli.Commands
             this.installers = installers;
 
             var options = Options.For("Install AutoComplete");
-            options.Add("shell=",
+            options.Add<SupportedShell>("shell=",
                 $"The type of shell to install auto-complete scripts for. This will alter your shell configuration files. Supported shells are {supportedShells}.",
-                v =>
-                {
-                    ShellSelection = Enum.TryParse(v, ignoreCase: true, out SupportedShell type)
-                        ? type
-                        : throw new CommandException(
-                            $"Unable to install autocomplete scripts into the {v} shell. Supported shells are {supportedShells}.");
-                });
-            options.Add("dryRun",
+                v => { ShellSelection = v; });
+            options.Add<bool>("dryRun",
                 "[Optional] Dry run will output the proposed changes to console, instead of writing to disk.",
                 v => DryRun = true);
         }

--- a/source/Octopus.Cli/Commands/Machine/ListMachinesCommand.cs
+++ b/source/Octopus.Cli/Commands/Machine/ListMachinesCommand.cs
@@ -16,8 +16,8 @@ namespace Octopus.Cli.Commands.Machine
     public class ListMachinesCommand : ApiCommand, ISupportFormattedOutput
     {
         readonly HashSet<string> environments = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        readonly HashSet<string> statuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        readonly HashSet<string> healthStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        readonly HashSet<MachineModelStatus> statuses = new HashSet<MachineModelStatus>();
+        readonly HashSet<MachineModelHealthStatus> healthStatuses = new HashSet<MachineModelHealthStatus>();
         private HealthStatusProvider provider;
         List<EnvironmentResource> environmentResources;
         IEnumerable<MachineResource> environmentMachines;
@@ -29,12 +29,12 @@ namespace Octopus.Cli.Commands.Machine
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing");
-            options.Add("environment=", "Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
-            options.Add("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
-            options.Add("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
-            options.Add("disabled=", "[Optional] Disabled status filter of Machine.", v => SetFlagState(v, ref isDisabled));
-            options.Add("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));
-            options.Add("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => SetFlagState(v, ref isTentacleOutdated));
+            options.Add<string>("environment=", "Name of an environment to filter by. Can be specified many times.", v => environments.Add(v));
+            options.Add<MachineModelStatus>("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
+            options.Add<MachineModelHealthStatus>("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
+            options.Add<bool>("disabled=", "[Optional] Disabled status filter of Machine.", v => isDisabled = v);
+            options.Add<bool>("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => isCalamariOutdated = v);
+            options.Add<bool>("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => isTentacleOutdated = v);
         }
 
         public async Task Request()

--- a/source/Octopus.Cli/Commands/Machine/ListWorkersCommand.cs
+++ b/source/Octopus.Cli/Commands/Machine/ListWorkersCommand.cs
@@ -15,8 +15,8 @@ namespace Octopus.Cli.Commands.Machine
     public class ListWorkersCommand : ApiCommand, ISupportFormattedOutput
     {
         readonly HashSet<string> pools = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        readonly HashSet<string> statuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        readonly HashSet<string> healthStatuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        readonly HashSet<MachineModelStatus> statuses = new HashSet<MachineModelStatus>();
+        readonly HashSet<MachineModelHealthStatus> healthStatuses = new HashSet<MachineModelHealthStatus>();
         private HealthStatusProvider provider;
         List<WorkerPoolResource> workerpoolResources;
         IEnumerable<WorkerResource> workerpoolWorkers;
@@ -28,12 +28,12 @@ namespace Octopus.Cli.Commands.Machine
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing Workers");
-            options.Add("workerpool=", "Name of a worker pool to filter by. Can be specified many times.", v => pools.Add(v));
-            options.Add("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
-            options.Add("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
-            options.Add("disabled=", "[Optional] Disabled status filter of Machine.", v => SetFlagState(v, ref isDisabled));
-            options.Add("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => SetFlagState(v, ref isCalamariOutdated));
-            options.Add("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => SetFlagState(v, ref isTentacleOutdated));
+            options.Add<string>("workerpool=", "Name of a worker pool to filter by. Can be specified many times.", v => pools.Add(v));
+            options.Add<MachineModelStatus>("status=", $"[Optional] Status of Machines filter by ({string.Join(", ", HealthStatusProvider.StatusNames)}). Can be specified many times.", v => statuses.Add(v));
+            options.Add<MachineModelHealthStatus>("health-status=|healthstatus=", $"[Optional] Health status of Machines filter by ({string.Join(", ", HealthStatusProvider.HealthStatusNames)}). Can be specified many times.", v => healthStatuses.Add(v));
+            options.Add<bool>("disabled=", "[Optional] Disabled status filter of Machine.", v => isDisabled = v);
+            options.Add<bool>("calamari-outdated=", "[Optional] State of Calamari to filter. By default ignores Calamari state.", v => isCalamariOutdated = v);
+            options.Add<bool>("tentacle-outdated=", "[Optional] State of Tentacle version to filter. By default ignores Tentacle state", v => isTentacleOutdated = v);
         }
 
         public async Task Request()

--- a/source/Octopus.Cli/Commands/Package/BuildInformationCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/BuildInformationCommand.cs
@@ -16,6 +16,7 @@ namespace Octopus.Cli.Commands.Package
     [Command("build-information", Description = "Pushes build information to Octopus Server.")]
     public class BuildInformationCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static OverwriteMode DefaultOverwriteMode = OverwriteMode.FailIfExists;
         private OctopusPackageVersionBuildInformationMappedResource resultResource;
         private readonly List<OctopusPackageVersionBuildInformationMappedResource> pushedBuildInformation;
 
@@ -26,7 +27,7 @@ namespace Octopus.Cli.Commands.Package
             options.Add<string>("package-id=", "The ID of the package. Specify multiple packages by specifying this argument multiple times: \n--package-id 'MyCompany.MyApp' --package-id 'MyCompany.MyApp2'.", packageId => PackageIds.Add(packageId));
             options.Add<string>("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add<string>("file=", "Octopus Build Information Json file.", file => File = file);
-            options.Add<OverwriteMode>("overwrite-mode=", "If the build information already exists in the repository, the default behavior is to reject the new build information being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
+            options.Add<OverwriteMode>("overwrite-mode=", $"Determines behavior if the package already exists in the repository. Valid values are {Enum.GetNames(typeof(OverwriteMode)).ReadableJoin()}. Default is {DefaultOverwriteMode}.", mode => OverwriteMode = mode);
 
             pushedBuildInformation = new List<OctopusPackageVersionBuildInformationMappedResource>();
         }
@@ -34,7 +35,8 @@ namespace Octopus.Cli.Commands.Package
         public HashSet<string> PackageIds { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         public string Version { get; set; }
         public string File { get; set; }
-        public OverwriteMode OverwriteMode { get; set; }
+
+        public OverwriteMode OverwriteMode { get; set; } = DefaultOverwriteMode;
 
         public async Task Request()
         {

--- a/source/Octopus.Cli/Commands/Package/BuildInformationCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/BuildInformationCommand.cs
@@ -23,10 +23,10 @@ namespace Octopus.Cli.Commands.Package
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Build information pushing");
-            options.Add("package-id=", "The ID of the package. Specify multiple packages by specifying this argument multiple times: \n--package-id 'MyCompany.MyApp' --package-id 'MyCompany.MyApp2'.", packageId => PackageIds.Add(packageId));
-            options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
-            options.Add("file=", "Octopus Build Information Json file.", file => File = file);
-            options.Add("overwrite-mode=", "If the build information already exists in the repository, the default behavior is to reject the new build information being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
+            options.Add<string>("package-id=", "The ID of the package. Specify multiple packages by specifying this argument multiple times: \n--package-id 'MyCompany.MyApp' --package-id 'MyCompany.MyApp2'.", packageId => PackageIds.Add(packageId));
+            options.Add<string>("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
+            options.Add<string>("file=", "Octopus Build Information Json file.", file => File = file);
+            options.Add<OverwriteMode>("overwrite-mode=", "If the build information already exists in the repository, the default behavior is to reject the new build information being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
 
             pushedBuildInformation = new List<OctopusPackageVersionBuildInformationMappedResource>();
         }

--- a/source/Octopus.Cli/Commands/Package/IPackageBuilder.cs
+++ b/source/Octopus.Cli/Commands/Package/IPackageBuilder.cs
@@ -3,6 +3,20 @@ using ManifestMetadata = NuGet.Packaging.ManifestMetadata;
 
 namespace Octopus.Cli.Commands.Package
 {
+    public enum PackageCompressionLevel
+    {
+        None,
+        Fast,
+        Optimal,
+    }
+    
+    public enum PackageFormat
+    {
+        Zip,
+        Nupkg,
+        Nuget,
+    }
+    
     public interface IPackageBuilder
     {
         string[] Files { get; }
@@ -11,6 +25,6 @@ namespace Octopus.Cli.Commands.Package
 
         void BuildPackage(string basePath, IList<string> includes, ManifestMetadata metadata, string outFolder, bool overwrite, bool verboseInfo);
 
-        void SetCompression(string level);
+        void SetCompression(PackageCompressionLevel level);
     }
 }

--- a/source/Octopus.Cli/Commands/Package/NuGetPackageBuilder.cs
+++ b/source/Octopus.Cli/Commands/Package/NuGetPackageBuilder.cs
@@ -54,7 +54,7 @@ namespace Octopus.Cli.Commands.Package
                 nugetPkgBuilder.Save(outStream);
         }
 
-        public void SetCompression(string level)
+        public void SetCompression(PackageCompressionLevel level)
         {
             // does nothing
             return;

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -15,6 +15,7 @@ namespace Octopus.Cli.Commands.Package
     [Command("push", Description = "Pushes a package (.nupkg, .zip, .tar.gz, etc.) package to the built-in NuGet repository in an Octopus Server.")]
     public class PushCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static OverwriteMode DefaultOverwriteMode = OverwriteMode.FailIfExists;
         private List<string> pushedPackages;
         private List<Tuple<string, Exception>> failedPackages;
 
@@ -24,7 +25,7 @@ namespace Octopus.Cli.Commands.Package
             var options = Options.For("Package pushing");
             options.Add<string>("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
                 package => Packages.Add(EnsurePackageExists(fileSystem, package)));
-            options.Add<OverwriteMode>("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
+            options.Add<OverwriteMode>("overwrite-mode=", $"Determines behavior if the package already exists in the repository. Valid values are {Enum.GetNames(typeof(OverwriteMode)).ReadableJoin()}. Default is {DefaultOverwriteMode}.", mode => OverwriteMode = mode);
             options.Add<bool>("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", 
                 replace => OverwriteMode = OverwriteMode.OverwriteExisting);
             options.Add<bool>("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",
@@ -34,7 +35,7 @@ namespace Octopus.Cli.Commands.Package
         }
 
         public HashSet<string> Packages { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase); 
-        public OverwriteMode OverwriteMode { get; set; }
+        public OverwriteMode OverwriteMode { get; set; } = DefaultOverwriteMode;
         public bool UseDeltaCompression { get; set; } = true;
 
         public int KeepAlive { get; set; } = 0;

--- a/source/Octopus.Cli/Commands/Package/PushCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushCommand.cs
@@ -22,18 +22,13 @@ namespace Octopus.Cli.Commands.Package
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Package pushing");
-            options.Add("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
+            options.Add<string>("package=", "Package file to push. Specify multiple packages by specifying this argument multiple times: \n--package package1 --package package2", 
                 package => Packages.Add(EnsurePackageExists(fileSystem, package)));
-            options.Add("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
-            options.Add("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", 
+            options.Add<OverwriteMode>("overwrite-mode=", "If the package already exists in the repository, the default behavior is to reject the new package being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
+            options.Add<bool>("replace-existing", "If the package already exists in the repository, the default behavior is to reject the new package being pushed. You can pass this flag to overwrite the existing package. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", 
                 replace => OverwriteMode = OverwriteMode.OverwriteExisting);
-            options.Add("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",
-                v =>
-                {
-                    if (!bool.TryParse(v, out var desiredValue))
-                        throw new CommandException($"The value '{v}' is not valid. Valid values are true or false.");
-                    UseDeltaCompression = desiredValue;
-                });
+            options.Add<bool>("use-delta-compression=", "Allows disabling of delta compression when uploading packages to the Octopus Server. (True or False. Defaults to true.)",
+                v => UseDeltaCompression = v);
             pushedPackages = new List<string>();
             failedPackages = new List<Tuple<string, Exception>>();
         }

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -19,11 +19,11 @@ namespace Octopus.Cli.Commands.Package
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Package metadata pushing");
-            options.Add("package-id=", "The ID of the package, e.g., 'MyCompany.MyApp'.", v => PackageId = v);
-            options.Add("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
-            options.Add("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
-            options.Add("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = (OverwriteMode)Enum.Parse(typeof(OverwriteMode), mode, true));
-            options.Add("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package metadata. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
+            options.Add<string>("package-id=", "The ID of the package, e.g., 'MyCompany.MyApp'.", v => PackageId = v);
+            options.Add<string>("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
+            options.Add<string>("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
+            options.Add<OverwriteMode>("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
+            options.Add<string>("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package metadata. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
         }
 
         public string PackageId { get; set; }

--- a/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
+++ b/source/Octopus.Cli/Commands/Package/PushMetadataCommand.cs
@@ -13,6 +13,8 @@ namespace Octopus.Cli.Commands.Package
     [Command("push-metadata", Description = "Pushes package metadata to Octopus Server.  Deprecated. Please use the build-information command for Octopus Server 2019.10.0 and above.")]
     public class PushMetadataCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static OverwriteMode DefaultOverwriteMode = OverwriteMode.FailIfExists;
+
         private OctopusPackageMetadataMappedResource resultResource;
 
         public PushMetadataCommand(IOctopusAsyncRepositoryFactory repositoryFactory, IOctopusFileSystem fileSystem, IOctopusClientFactory clientFactory, ICommandOutputProvider commandOutputProvider)
@@ -22,14 +24,14 @@ namespace Octopus.Cli.Commands.Package
             options.Add<string>("package-id=", "The ID of the package, e.g., 'MyCompany.MyApp'.", v => PackageId = v);
             options.Add<string>("version=", "The version of the package; defaults to a timestamp-based version", v => Version = v);
             options.Add<string>("metadata-file=", "Octopus Package metadata Json file.", file => MetadataFile = file);
-            options.Add<OverwriteMode>("overwrite-mode=", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed (FailIfExists). You can use the overwrite mode to OverwriteExisting or IgnoreIfExists.", mode => OverwriteMode = mode);
+            options.Add<OverwriteMode>("overwrite-mode=", $"Determines behavior if the package already exists in the repository. Valid values are {Enum.GetNames(typeof(OverwriteMode)).ReadableJoin()}. Default is {DefaultOverwriteMode}.", mode => OverwriteMode = mode);
             options.Add<string>("replace-existing", "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. You can pass this flag to overwrite the existing package metadata. This flag may be deprecated in a future version; passing it is the same as using the OverwriteExisting overwrite-mode.", replace => OverwriteMode = OverwriteMode.OverwriteExisting);
         }
 
         public string PackageId { get; set; }
         public string Version { get; set; }
         public string MetadataFile { get; set; }
-        public OverwriteMode OverwriteMode { get; set; }
+        public OverwriteMode OverwriteMode { get; set; } = DefaultOverwriteMode;
 
         public async Task Request()
         {

--- a/source/Octopus.Cli/Commands/Package/ZipPackageBuilder.cs
+++ b/source/Octopus.Cli/Commands/Package/ZipPackageBuilder.cs
@@ -89,7 +89,7 @@ namespace Octopus.Cli.Commands.Package
                     compressionLevel = CompressionLevel.Optimal;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
+                    throw new CommandException($"Unexpected compression value `{level}'. Valid values are {Enum.GetNames(typeof(PackageCompressionLevel)).ReadableJoin()}.");
             }
 
             commandOutputProvider.Information($"Setting Zip compression level to {compressionLevel.ToString()}");

--- a/source/Octopus.Cli/Commands/Package/ZipPackageBuilder.cs
+++ b/source/Octopus.Cli/Commands/Package/ZipPackageBuilder.cs
@@ -75,23 +75,21 @@ namespace Octopus.Cli.Commands.Package
             }
         }
 
-        public void SetCompression(string level)
+        public void SetCompression(PackageCompressionLevel level)
         {
-            if (string.IsNullOrWhiteSpace(level))
+            switch(level)
             {
-                compressionLevel = CompressionLevel.Optimal;
-            }
-            else if (level.Equals("none", StringComparison.CurrentCultureIgnoreCase))
-            {
-                compressionLevel = CompressionLevel.NoCompression;
-            }
-            else if (level.Equals("fast", StringComparison.CurrentCultureIgnoreCase))
-            {
-                compressionLevel = CompressionLevel.Fastest;
-            }
-            else
-            {
-                compressionLevel = CompressionLevel.Optimal;
+                case PackageCompressionLevel.None:
+                    compressionLevel = CompressionLevel.NoCompression;
+                    break;
+                case PackageCompressionLevel.Fast:
+                    compressionLevel = CompressionLevel.Fastest;
+                    break;
+                case PackageCompressionLevel.Optimal:
+                    compressionLevel = CompressionLevel.Optimal;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
             }
 
             commandOutputProvider.Information($"Setting Zip compression level to {compressionLevel.ToString()}");

--- a/source/Octopus.Cli/Commands/Project/CreateProjectCommand.cs
+++ b/source/Octopus.Cli/Commands/Project/CreateProjectCommand.cs
@@ -20,10 +20,10 @@ namespace Octopus.Cli.Commands.Project
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Project creation");
-            options.Add("name=", "The name of the project", v => ProjectName = v);
-            options.Add("projectGroup=", "The name of the project group to add this project to. If the group doesn't exist, it will be created.", v => ProjectGroupName = v);
-            options.Add("lifecycle=", "The name of the lifecycle that the project will use.", v=> LifecycleName = v);
-            options.Add("ignoreIfExists", "If the project already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
+            options.Add<string>("name=", "The name of the project", v => ProjectName = v);
+            options.Add<string>("projectGroup=", "The name of the project group to add this project to. If the group doesn't exist, it will be created.", v => ProjectGroupName = v);
+            options.Add<string>("lifecycle=", "The name of the lifecycle that the project will use.", v=> LifecycleName = v);
+            options.Add<bool>("ignoreIfExists", "If the project already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
         }
 
         public string ProjectName { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
@@ -19,9 +19,8 @@ namespace Octopus.Cli.Commands.Releases
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Allowing release progression.");
-            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("version=|releaseNumber=", "Release version/number",
-                v => ReleaseVersionNumber = v);
+            options.Add<string>("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add<string>("version=|releaseNumber=", "Release version/number", v => ReleaseVersionNumber = v);
         }
 
         public string ProjectNameOrId { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -31,21 +31,21 @@ namespace Octopus.Cli.Commands.Releases
             this.releasePlanBuilder = releasePlanBuilder;
 
             var options = Options.For("Release creation");
-            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
-            options.Add("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
-            options.Add("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
-            options.Add("package=", "[Optional] Version number to use for a package in the release. Format: StepName:Version or PackageID:Version or StepName:PackageName:Version. StepName, PackageID, and PackageName can be replaced with an asterisk. An asterisk will be assumed for StepName, PackageID, or PackageName if they are omitted.", v => versionResolver.Add(v));
-            options.Add("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => {v.CheckForIllegalPathCharacters("packagesFolder"); versionResolver.AddFolder(v);});
-            options.Add("releasenotes=", "[Optional] Release Notes for the new release. Styling with Markdown is supported.", v => ReleaseNotes = v);
-            options.Add("releasenotesfile=", "[Optional] Path to a file that contains Release Notes for the new release. Supports Markdown files.", ReadReleaseNotesFromFile);
-            options.Add("ignoreexisting", "[Optional, Flag] Don't create this release if there is already one with the same version number.", v => IgnoreIfAlreadyExists = true);
-            options.Add("ignorechannelrules", "[Optional, Flag] Create the release ignoring any version rules specified by the channel.", v => IgnoreChannelRules = true);
-            options.Add("packageprerelease=", "[Optional] Pre-release for latest version of all packages to use for this release.", v => VersionPreReleaseTag = v);
-            options.Add("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
+            options.Add<string>("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add<string>("defaultpackageversion=|packageversion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
+            options.Add<string>("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
+            options.Add<string>("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
+            options.Add<string>("package=", "[Optional] Version number to use for a package in the release. Format: StepName:Version or PackageID:Version or StepName:PackageName:Version. StepName, PackageID, and PackageName can be replaced with an asterisk. An asterisk will be assumed for StepName, PackageID, or PackageName if they are omitted.", v => versionResolver.Add(v));
+            options.Add<string>("packagesFolder=", "[Optional] A folder containing NuGet packages from which we should get versions.", v => {v.CheckForIllegalPathCharacters("packagesFolder"); versionResolver.AddFolder(v);});
+            options.Add<string>("releasenotes=", "[Optional] Release Notes for the new release. Styling with Markdown is supported.", v => ReleaseNotes = v);
+            options.Add<string>("releasenotesfile=", "[Optional] Path to a file that contains Release Notes for the new release. Supports Markdown files.", ReadReleaseNotesFromFile);
+            options.Add<bool>("ignoreexisting", "[Optional, Flag] Don't create this release if there is already one with the same version number.", v => IgnoreIfAlreadyExists = true);
+            options.Add<bool>("ignorechannelrules", "[Optional, Flag] Create the release ignoring any version rules specified by the channel.", v => IgnoreChannelRules = true);
+            options.Add<string>("packageprerelease=", "[Optional] Pre-release for latest version of all packages to use for this release.", v => VersionPreReleaseTag = v);
+            options.Add<bool>("whatif", "[Optional, Flag] Perform a dry run but don't actually create/deploy release.", v => WhatIf = true);
 
             options = Options.For("Deployment");
-            options.Add("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add<string>("deployto=", "[Optional] Name or ID of the environment to automatically deploy to, e.g., 'Production' or 'Environments-1'; specify this argument multiple times to deploy to multiple environments.", v => DeployToEnvironmentNamesOrIds.Add(v));
         }
 
         public string ChannelNameOrId { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -24,11 +24,11 @@ namespace Octopus.Cli.Commands.Releases
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Deletion");
-            options.Add("project=", "Name of the project", v => ProjectName = v);
-            options.Add("minversion=", "Minimum (inclusive) version number for the range of versions to delete", v => MinVersion = v);
-            options.Add("maxversion=", "Maximum (inclusive) version number for the range of versions to delete", v => MaxVersion = v);
-            options.Add("channel=", "[Optional] if specified, only releases associated with the channel will be deleted; specify this argument multiple times to target multiple channels.", v => ChannelNames.Add(v));
-            options.Add("whatif", "[Optional, Flag] if specified, releases won't actually be deleted, but will be listed as if simulating the command", v => WhatIf = true);
+            options.Add<string>("project=", "Name of the project", v => ProjectName = v);
+            options.Add<string>("minversion=", "Minimum (inclusive) version number for the range of versions to delete", v => MinVersion = v);
+            options.Add<string>("maxversion=", "Maximum (inclusive) version number for the range of versions to delete", v => MaxVersion = v);
+            options.Add<string>("channel=", "[Optional] if specified, only releases associated with the channel will be deleted; specify this argument multiple times to target multiple channels.", v => ChannelNames.Add(v));
+            options.Add<bool>("whatif", "[Optional, Flag] if specified, releases won't actually be deleted, but will be listed as if simulating the command", v => WhatIf = true);
         }
 
         public string ProjectName { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/ListReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/ListReleasesCommand.cs
@@ -23,7 +23,7 @@ namespace Octopus.Cli.Commands.Releases
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Listing");
-            options.Add("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
+            options.Add<string>("project=", "Name of a project to filter by. Can be specified many times.", v => projects.Add(v));
         }
 
 

--- a/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
@@ -19,11 +19,9 @@ namespace Octopus.Cli.Commands.Releases
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("Preventing release progression.");
-            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("version=|releaseNumber=", "Release version/number",
-                v => ReleaseVersionNumber = v);
-            options.Add("reason=", "Reason to prevent this release from progressing to next phase",
-                v => ReasonToPrevent = v);
+            options.Add<string>("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add<string>("version=|releaseNumber=", "Release version/number", v => ReleaseVersionNumber = v);
+            options.Add<string>("reason=", "Reason to prevent this release from progressing to next phase", v => ReasonToPrevent = v);
         }
 
         public string ProjectNameOrId { get; set; }

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -21,10 +21,10 @@ namespace Octopus.Cli.Commands.Releases
             : base(repositoryFactory, fileSystem, clientFactory, commandOutputProvider)
         {
             var options = Options.For("Release Promotion");
-            options.Add("project=", "Name or ID of the project", v => ProjectNameOrId = v);
-            options.Add("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentNameOrId = v);
-            options.Add("to=|deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
-            options.Add("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
+            options.Add<string>("project=", "Name or ID of the project", v => ProjectNameOrId = v);
+            options.Add<string>("from=", "Name or ID of the environment to get the current deployment from, e.g., 'Staging' or 'Environments-2'.", v => FromEnvironmentNameOrId = v);
+            options.Add<string>("to=|deployto=", "Name or ID of the environment to deploy to, e.g., 'Production' or 'Environments-1'.", v => DeployToEnvironmentNamesOrIds.Add(v));
+            options.Add<bool>("updateVariables", "Overwrite the variable snapshot for the release by re-importing the variables from the project", v => UpdateVariableSnapshot = true);
         }
 
         public string FromEnvironmentNameOrId { get; set; }

--- a/source/Octopus.Cli/Commands/WorkerPool/CreateWorkerPoolCommand.cs
+++ b/source/Octopus.Cli/Commands/WorkerPool/CreateWorkerPoolCommand.cs
@@ -16,8 +16,8 @@ namespace Octopus.Cli.Commands.WorkerPool
             : base(clientFactory, repositoryFactory, fileSystem, commandOutputProvider)
         {
             var options = Options.For("WorkerPool creation");
-            options.Add("name=", "The name of the worker pool", v => WorkerPoolName = v);
-            options.Add("ignoreIfExists", "If the pool already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
+            options.Add<string>("name=", "The name of the worker pool", v => WorkerPoolName = v);
+            options.Add<bool>("ignoreIfExists", "If the pool already exists, an error will be returned. Set this flag to ignore the error.", v => IgnoreIfExists = true);
         }
 
         public string WorkerPoolName { get; set; }

--- a/source/Octopus.Cli/Diagnostics/LogUtilities.cs
+++ b/source/Octopus.Cli/Diagnostics/LogUtilities.cs
@@ -36,7 +36,7 @@ namespace Octopus.Cli.Diagnostics
         {
             var description = $"[Optional] The log level. Valid options are {GetValidOptions()}. " +
                               $"Defaults to '{DefaultLogLevel.ToString().ToLowerInvariant()}'.";
-            options.Add("logLevel=", description, s => LevelSwitch.MinimumLevel = ParseLogLevel(s));
+            options.Add<LogEventLevel>("logLevel=", description, s => LevelSwitch.MinimumLevel = s);
         }
 
         private static string GetValidOptions()

--- a/source/Octopus.Cli/Infrastructure/Options.cs
+++ b/source/Octopus.Cli/Infrastructure/Options.cs
@@ -692,7 +692,7 @@ namespace Octopus.Cli.Infrastructure
 #pragma warning disable 618
             var currentOption = GetOptionForName("<>");
 #pragma warning restore 618
-            var unprocessed = arguments.Where(argument => Predicate(argument, optionContext, currentOption, ref process));
+            var unprocessed = arguments.Where(argument => ParseOption(argument, optionContext, currentOption, ref process));
             var r = unprocessed.ToList();
             optionContext.Option?.Invoke(optionContext);
 
@@ -704,7 +704,7 @@ namespace Octopus.Cli.Infrastructure
             return r;
         }
 
-        private bool Predicate(string argument, OptionContext optionContext, Option currentOption, ref bool continueProcessing)
+        private bool ParseOption(string argument, OptionContext optionContext, Option currentOption, ref bool continueProcessing)
         {
             if (++optionContext.OptionIndex >= 0 && (continueProcessing || currentOption != null))
             {

--- a/source/Octopus.Cli/Infrastructure/Options.cs
+++ b/source/Octopus.Cli/Infrastructure/Options.cs
@@ -132,6 +132,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Octopus.Cli.Util;
 
 namespace Octopus.Cli.Infrastructure
 {
@@ -337,12 +338,12 @@ namespace Octopus.Cli.Infrastructure
     {
         static readonly char[] NameTerminator = {'=', ':'};
 
-        protected Option(string prototype, string description)
-            : this(prototype, description, 1)
+        protected Option(string prototype, string description, bool sensitive = false)
+            : this(prototype, description, 1, sensitive)
         {
         }
 
-        protected Option(string prototype, string description, int maxValueCount)
+        protected Option(string prototype, string description, int maxValueCount, bool sensitive = false)
         {
             if (prototype == null)
                 throw new ArgumentNullException(nameof(prototype));
@@ -355,6 +356,7 @@ namespace Octopus.Cli.Infrastructure
             Names = prototype.Split('|');
             this.Description = description;
             MaxValueCount = maxValueCount;
+            Sensitive = sensitive;
             OptionValueType = ParsePrototype();
 
             if (MaxValueCount == 0 && OptionValueType != OptionValueType.None)
@@ -381,10 +383,12 @@ namespace Octopus.Cli.Infrastructure
         public OptionValueType OptionValueType { get; }
 
         public int MaxValueCount { get; }
+        public bool Sensitive { get; }
 
         internal string[] Names { get; }
 
         internal string[] ValueSeparators { get; private set; }
+        public abstract Type Type { get; }
 
         public string[] GetNames()
         {
@@ -407,9 +411,13 @@ namespace Octopus.Cli.Infrastructure
                 if (value != null)
                     t = (T) conv.ConvertFromString(value);
             }
-            catch (Exception e)
+            catch(FormatException) when(typeof(T).IsEnum)
             {
-                throw new OptionException($"Could not convert string `{value}' to type {typeof(T).Name} for option `{c.OptionName}'.", c.OptionName, e);
+                throw new CommandException($"Could not convert string `{value}' to type {typeof(T).Name} for option `{c.OptionName}'. Valid values are {Enum.GetNames(typeof(T)).ReadableJoin()}.");
+            }
+            catch(Exception ex) when(!(ex is CommandException))
+            {
+                throw new CommandException($"Could not convert string `{value}' to type {typeof(T).Name} for option `{c.OptionName}'.");
             }
             return t;
         }
@@ -624,77 +632,34 @@ namespace Octopus.Cli.Infrastructure
                 this.action = action;
             }
 
+            public override Type Type => typeof(string);
+
             protected override void OnParseComplete(OptionContext c)
             {
                 action(c.OptionValues);
             }
         }
 
-        public OptionSet Add(string prototype, Action<string> action)
-        {
-            return Add(prototype, null, action);
-        }
-
-        public OptionSet Add(string prototype, string description, Action<string> action)
-        {
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
-            Option p = new ActionOption(prototype, description, 1,
-                delegate(OptionValueCollection v) { action(v[0]); });
-            base.Add(p);
-            return this;
-        }
-
-        public OptionSet Add(string prototype, OptionAction<string, string> action)
-        {
-            return Add(prototype, null, action);
-        }
-
-        public OptionSet Add(string prototype, string description, OptionAction<string, string> action)
-        {
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
-            Option p = new ActionOption(prototype, description, 2,
-                delegate(OptionValueCollection v) { action(v[0], v[1]); });
-            base.Add(p);
-            return this;
-        }
-
         sealed class ActionOption<T> : Option
         {
             readonly Action<T> action;
 
-            public ActionOption(string prototype, string description, Action<T> action)
-                : base(prototype, description, 1)
+            public ActionOption(string prototype, string description, Action<T> action, bool sensitive)
+                : base(prototype, description, 1, sensitive)
             {
                 if (action == null)
                     throw new ArgumentNullException(nameof(action));
                 this.action = action;
             }
 
-            protected override void OnParseComplete(OptionContext c)
-            {
-                action(Parse<T>(c.OptionValues[0], c));
-            }
-        }
-
-        sealed class ActionOption<TKey, TValue> : Option
-        {
-            readonly OptionAction<TKey, TValue> action;
-
-            public ActionOption(string prototype, string description, OptionAction<TKey, TValue> action)
-                : base(prototype, description, 2)
-            {
-                if (action == null)
-                    throw new ArgumentNullException(nameof(action));
-                this.action = action;
-            }
+            public override Type Type => typeof(T);
 
             protected override void OnParseComplete(OptionContext c)
             {
-                action(
-                    Parse<TKey>(c.OptionValues[0], c),
-                    Parse<TValue>(c.OptionValues[1], c));
+                if (this.OptionValueType == OptionValueType.None)
+                    action(default(T));
+                else
+                    action(Parse<T>(c.OptionValues[0], c));
             }
         }
 
@@ -703,19 +668,9 @@ namespace Octopus.Cli.Infrastructure
             return Add(prototype, null, action);
         }
 
-        public OptionSet Add<T>(string prototype, string description, Action<T> action)
+        public OptionSet Add<T>(string prototype, string description, Action<T> action, bool sensitive = false)
         {
-            return Add(new ActionOption<T>(prototype, description, action));
-        }
-
-        public OptionSet Add<TKey, TValue>(string prototype, OptionAction<TKey, TValue> action)
-        {
-            return Add(prototype, null, action);
-        }
-
-        public OptionSet Add<TKey, TValue>(string prototype, string description, OptionAction<TKey, TValue> action)
-        {
-            return Add(new ActionOption<TKey, TValue>(prototype, description, action));
+            return Add(new ActionOption<T>(prototype, description, action, sensitive));
         }
 
         protected virtual OptionContext CreateOptionContext()
@@ -732,30 +687,14 @@ namespace Octopus.Cli.Infrastructure
         public List<string> Parse(IEnumerable<string> arguments)
         {
             var process = true;
-            var c = CreateOptionContext();
-            c.OptionIndex = -1;
+            var optionContext = CreateOptionContext();
+            optionContext.OptionIndex = -1;
 #pragma warning disable 618
-            var def = GetOptionForName("<>");
+            var currentOption = GetOptionForName("<>");
 #pragma warning restore 618
-            var unprocessed =
-                from argument in arguments
-                where ++c.OptionIndex >= 0 && (process || def != null)
-                    ? process
-                        ? argument == "--"
-                            ? (process = false)
-                            : !Parse(argument, c)
-                                ? def != null
-                                    ? Unprocessed(null, def, c, argument)
-                                    : true
-                                : false
-                        : def != null
-                            ? Unprocessed(null, def, c, argument)
-                            : true
-                    : true
-                select argument;
+            var unprocessed = arguments.Where(argument => Predicate(argument, optionContext, currentOption, ref process));
             var r = unprocessed.ToList();
-            if (c.Option != null)
-                c.Option.Invoke(c);
+            optionContext.Option?.Invoke(optionContext);
 
             if (leftovers != null && r.Count > 0)
             {
@@ -763,6 +702,31 @@ namespace Octopus.Cli.Infrastructure
             }
 
             return r;
+        }
+
+        private bool Predicate(string argument, OptionContext optionContext, Option currentOption, ref bool continueProcessing)
+        {
+            if (++optionContext.OptionIndex >= 0 && (continueProcessing || currentOption != null))
+            {
+                if (continueProcessing)
+                {
+                    if (argument == "--")
+                        return continueProcessing = false;
+                    if (!Parse(argument, optionContext))
+                    {
+                        if (currentOption != null)
+                            return Unprocessed(null, currentOption, optionContext, argument);
+                        return true;
+                    }
+                    return false;
+                }
+
+                if (currentOption != null)
+                    return Unprocessed(null, currentOption, optionContext, argument);
+                return true;
+            }
+
+            return true;
         }
 
         static bool Unprocessed(ICollection<string> extra, Option def, OptionContext c, string argument)

--- a/source/Octopus.Cli/Util/CommandOutputProvider.cs
+++ b/source/Octopus.Cli/Util/CommandOutputProvider.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Octopus.Cli.Diagnostics;
 using Octopus.Cli.Infrastructure;
 using Octopus.Client.Model;
@@ -102,7 +103,13 @@ namespace Octopus.Cli.Util
         
         public void Json(object o, TextWriter writer)
         {
-            writer.WriteLine(Octopus.Client.Serialization.JsonSerialization.SerializeObject(o));
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Formatting = Formatting.Indented,
+                Converters = new JsonConverterCollection { new StringEnumConverter() },
+            };
+            writer.WriteLine(JsonConvert.SerializeObject(o, settings));
         }
 
         public void Warning(string s)


### PR DESCRIPTION
Instead of just assuming all our command line options are strings, this PR changes our options parsing to use generics, and uses the built in option parsing.

This means:
* we dont need to do safe parsing (which we were doing inconsistently anyway - quite a few commands failed if you passed invalid data)
* we parse enums properly (one of our tests was using dodgy data and we didn't know
* we now flag sensitive options
* our (json formatted) help output now includes data types and enum values

All this is part of a side project to auto-generate the specification required for nuke build.
See https://github.com/nuke-build/nuke/blob/develop/build/specifications/Octopus.json