### PR TITLE
Add support for ubuntu focal, new LTS

### DIFF
--- a/BuildAssets/create-linux-packages.sh
+++ b/BuildAssets/create-linux-packages.sh
@@ -51,7 +51,7 @@ fpm --version "$VERSION" \
   --depends 'libssl1.0.0 | libssl1.0.2 | libssl1.1' \
   --depends 'libkrb5-3' \
   --depends 'zlib1g' \
-  --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63' \
+  --depends 'libicu52 | libicu55 | libicu57 | libicu60 | libicu63 | libicu66' \
   "$OCTOPUSCLI_BINARIES=/opt/octopus/octopuscli" \
   tmp_usr_bin/=/usr/bin/ \
   || exit

--- a/BuildAssets/repos/publish-apt.sh
+++ b/BuildAssets/repos/publish-apt.sh
@@ -34,7 +34,7 @@ CURL_UPL_OPTS=(--silent --show-error --fail --user "$PUBLISH_ARTIFACTORY_USERNAM
 echo "Uploading package to Artifactory"
 PKG=$(set -o pipefail; ls -1 *.deb | head -n1) || exit
 PKGBN=$(basename "$PKG")
-DISTS=(oldoldstable oldstable stable jessie stretch buster trusty xenial bionic cosmic disco eoan)
+DISTS=(oldoldstable oldstable stable jessie stretch buster trusty xenial bionic cosmic disco eoan focal)
 DISTS=$(printf ";deb.distribution=%s" "${DISTS[@]}")
 curl "${CURL_UPL_OPTS[@]}" --request PUT --upload-file "$PKG" \
   "https://octopusdeploy.jfrog.io/octopusdeploy/$REPO_KEY/pool/main/${PKGBN:0:1}/${PKGBN/%_*/}/$PKGBN$DISTS;deb.component=main;deb.architecture=amd64" \


### PR DESCRIPTION
This includes two changes to make Octopus CLI install properly in the new LTS ubuntu focal:

- Adds the `libicu` dependency with the new version number for focal
- Adds 'focal' as one of the dist specifiers we support
