### PR TITLE
Bumps client version to 8.8.1

### DIFF
--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="8.8.0" />
+    <PackageReference Include="Octopus.Client" Version="8.8.1" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Runbooks/RunRunbookCommand.cs
+++ b/source/Octopus.Cli/Commands/Runbooks/RunRunbookCommand.cs
@@ -119,7 +119,7 @@ namespace Octopus.Cli.Commands.Runbooks
             options.Add<bool>("progress", "[Optional] Show progress of the runbook run", v => { Progress = true; WaitForRun = true; NoRawLog = true; });
 
             options.Add<TimeSpan>("runTimeout=",
-                "[Optional] Specifies maximum time (timespan format) that the console session will wait for the runbook run to finish(default 00:10:00). This will not stop the run. Requires -- waitfordeployment parameter set.",
+                "[Optional] Specifies maximum time (timespan format) that the console session will wait for the runbook run to finish (default 00:10:00). This will not stop the run. Requires --waitForRun parameter to be set.",
                 v => RunTimeout = v);
 
             options.Add<bool>("cancelOnTimeout",

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="8.8.0" />
+    <PackageReference Include="Octopus.Client" Version="8.8.1" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />


### PR DESCRIPTION
Bumps the OctopusClient version 8.8.0->8.8.1

Client update is to facilitate server version checking for backward compatibility of this too with previous API endpoints.