### PR TITLE
Minor packaging improvements

### DIFF
--- a/BuildAssets/create-octopuscli-linux-packages.sh
+++ b/BuildAssets/create-octopuscli-linux-packages.sh
@@ -49,4 +49,4 @@ FPM_RPM_OPTS=(
   --depends 'libicu'
 )
 
-source /opt/linux-package-feeds/create-linux-packages.sh
+source /opt/linux-package-feeds/create-linux-packages.sh || exit

--- a/BuildAssets/create-octopuscli-linux-packages.sh
+++ b/BuildAssets/create-octopuscli-linux-packages.sh
@@ -19,7 +19,9 @@ which fpm >/dev/null || {
   exit 1
 }
 if [[ ! -e /opt/linux-package-feeds ]]; then
-  echo "This script requires tools in '/opt/linux-package-feeds'. If running inside a container, check the volume mounts." >&2
+  echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi
 

--- a/BuildAssets/create-octopuscli-linux-packages.sh
+++ b/BuildAssets/create-octopuscli-linux-packages.sh
@@ -20,7 +20,7 @@ which fpm >/dev/null || {
 }
 if [[ ! -e /opt/linux-package-feeds ]]; then
   echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
-  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds, distributed in TeamCity" >&2
   echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi

--- a/BuildAssets/create-octopuscli-linux-packages.sh
+++ b/BuildAssets/create-octopuscli-linux-packages.sh
@@ -26,6 +26,7 @@ if [[ ! -e /opt/linux-package-feeds ]]; then
 fi
 
 
+# Create .deb and .rpm packages, with executable permission and a /usr/bin symlink, using a script from 'linux-package-feeds'.
 COMMAND_FILE=octo
 INSTALL_PATH=/opt/octopus/octopuscli
 PACKAGE_NAME=octopuscli
@@ -50,5 +51,4 @@ FPM_RPM_OPTS=(
   --depends 'zlib'
   --depends 'libicu'
 )
-
 source /opt/linux-package-feeds/create-linux-packages.sh || exit

--- a/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
@@ -3,7 +3,7 @@
 
 if [[ ! -e "$LPF_PATH" ]]; then
   echo "This script requires the environment variable LPF_PATH - the location of 'linux-package-feeds' scripts to use." >&2
-  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds, distributed in TeamCity" >&2
   echo "  via 'Infrastructure / Linux Package Feeds'." >&2
   exit 1
 fi

--- a/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
@@ -2,7 +2,9 @@
 # Smoke test our apt and rpm feeds in various dockerized distros.
 
 if [[ ! -e "$LPF_PATH" ]]; then
-  echo 'This script requires the environment variable LPF_PATH - the location of "linux-package-feeds" tools to use.' >&2
+  echo "This script requires the environment variable LPF_PATH - the location of 'linux-package-feeds' scripts to use." >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "  via 'Infrastructure / Linux Package Feeds'." >&2
   exit 1
 fi
 if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then

--- a/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
@@ -24,7 +24,7 @@ do
   echo "== Testing in '$DOCKER_IMAGE' =="
   docker pull "$DOCKER_IMAGE" >/dev/null || exit
   docker run --rm \
-    --hostname "testfeedpkgs$RANDOM" \
+    --hostname "octotestfeedpkg$RANDOM" \
     --volume "$(pwd):/working" --volume "$SCRIPT_DIR/test-linux-package-from-feed.sh:/test-linux-package-from-feed.sh" \
     --volume "$(realpath "$LPF_PATH"):/opt/linux-package-feeds" \
     --env PUBLISH_LINUX_EXTERNAL \

--- a/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed-in-dists.sh
@@ -9,7 +9,6 @@ if [[ -z "$PUBLISH_LINUX_EXTERNAL" ]]; then
   echo 'This script requires the environment variable PUBLISH_LINUX_EXTERNAL - specify "true" to test the external public feed.' >&2
   exit 1
 fi
-OSRELID="$(. /etc/os-release && echo $ID)"
 if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then
   echo -e 'This script requires the environment variables OCTOPUS_CLI_SERVER, OCTOPUS_CLI_API_KEY, OCTOPUS_SPACE, and'\
     '\nOCTOPUS_EXPECT_ENV - specifying an Octopus server for testing "list-environments", an API key to access it, the'\

--- a/BuildAssets/repos/test-linux-package-from-feed.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed.sh
@@ -26,12 +26,12 @@ if [[ ! -e /opt/linux-package-feeds ]]; then
 fi
 
 
+# Install the packages from our package feed (with any needed docker config, system registration) using a script from 'linux-package-feeds'.
 export PKG_NAMES="octopuscli tentacle"
 # TODO: (ZZDY) Remove this workaround once tentacle is added to focal repo
 if grep --quiet focal /etc/apt/sources.list 2>/dev/null; then
   PKG_NAMES="octopuscli"
 fi
-
 bash /opt/linux-package-feeds/install-linux-feed-package.sh || exit
 
 if command -v dpkg > /dev/null; then

--- a/BuildAssets/repos/test-linux-package-from-feed.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed.sh
@@ -19,7 +19,9 @@ if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPAC
 fi
 
 if [[ ! -e /opt/linux-package-feeds ]]; then
-  echo "This script requires tools in '/opt/linux-package-feeds'. If running inside a container, check the volume mounts." >&2
+  echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi
 

--- a/BuildAssets/repos/test-linux-package-from-feed.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed.sh
@@ -46,6 +46,6 @@ echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment
 # TODO: (ZZDY) Remove this workaround once tentacle is added to focal repo
 if [[ ! "$PKG_NAMES" == *tentacle ]]; then exit 0; fi
 
-echo Softly smoke-testing tentacle.
-/opt/octopus/tentacle/Tentacle version
+echo Testing tentacle.
+/opt/octopus/tentacle/Tentacle version || exit
 echo

--- a/BuildAssets/repos/test-linux-package-from-feed.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed.sh
@@ -20,7 +20,7 @@ fi
 
 if [[ ! -e /opt/linux-package-feeds ]]; then
   echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
-  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds, distributed in TeamCity" >&2
   echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi

--- a/BuildAssets/test-linux-package-in-dists.sh
+++ b/BuildAssets/test-linux-package-in-dists.sh
@@ -3,7 +3,7 @@
 
 if [[ ! -e "$LPF_PATH" ]]; then
   echo "This script requires the environment variable LPF_PATH - the location of 'linux-package-feeds' scripts to use." >&2
-  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds, distributed in TeamCity" >&2
   echo "  via 'Infrastructure / Linux Package Feeds'." >&2
   exit 1
 fi

--- a/BuildAssets/test-linux-package-in-dists.sh
+++ b/BuildAssets/test-linux-package-in-dists.sh
@@ -2,7 +2,9 @@
 # Test that .deb and .rpm packages in the working directory install an octo command that can list-environments.
 
 if [[ ! -e "$LPF_PATH" ]]; then
-  echo 'This script requires the environment variable LPF_PATH - the location of "linux-package-feeds" tools to use.' >&2
+  echo "This script requires the environment variable LPF_PATH - the location of 'linux-package-feeds' scripts to use." >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "  via 'Infrastructure / Linux Package Feeds'." >&2
   exit 1
 fi
 if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPACE" || -z "$OCTOPUS_EXPECT_ENV" ]]; then

--- a/BuildAssets/test-linux-package-in-dists.sh
+++ b/BuildAssets/test-linux-package-in-dists.sh
@@ -24,7 +24,7 @@ do
   echo "== Testing in '$DOCKER_IMAGE' =="
   docker pull "$DOCKER_IMAGE" >/dev/null || exit
   docker run --rm \
-    --hostname "testpkgs$RANDOM" \
+    --hostname "octotestpkg$RANDOM" \
     --volume "$(pwd):/working" --volume "$SCRIPT_DIR/test-linux-package.sh:/test-linux-package.sh" \
     --volume "$(realpath "$LPF_PATH"):/opt/linux-package-feeds" \
     --env OCTOPUS_CLI_SERVER --env OCTOPUS_CLI_API_KEY --env OCTOPUS_SPACE --env OCTOPUS_EXPECT_ENV \

--- a/BuildAssets/test-linux-package.sh
+++ b/BuildAssets/test-linux-package.sh
@@ -15,7 +15,9 @@ if [[ "$OSRELID" == "rhel" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHA
 fi
 
 if [[ ! -e /opt/linux-package-feeds ]]; then
-  echo "This script requires tools in '/opt/linux-package-feeds'. If running inside a container, check the volume mounts." >&2
+  echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi
 

--- a/BuildAssets/test-linux-package.sh
+++ b/BuildAssets/test-linux-package.sh
@@ -22,6 +22,7 @@ if [[ ! -e /opt/linux-package-feeds ]]; then
 fi
 
 
+# Install the package (with any needed docker config, system registration, dependencies) using a script from 'linux-package-feeds'.
 export PKG_PATH_PREFIX="octopuscli"
 bash /opt/linux-package-feeds/install-linux-package.sh || exit
 

--- a/BuildAssets/test-linux-package.sh
+++ b/BuildAssets/test-linux-package.sh
@@ -16,7 +16,7 @@ fi
 
 if [[ ! -e /opt/linux-package-feeds ]]; then
   echo "This script requires 'linux-package-feeds' scripts, installed in '/opt/linux-package-feeds'." >&2
-  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source, distributed in TeamCity" >&2
+  echo "They come from https://github.com/OctopusDeploy/linux-package-feeds, distributed in TeamCity" >&2
   echo "  via 'Infrastructure / Linux Package Feeds'. If running inside a Docker container, supply them using a volume mount." >&2
   exit 1
 fi

--- a/build.cake
+++ b/build.cake
@@ -343,7 +343,7 @@ Task("CreateLinuxPackages")
     .IsDependentOn("AssertLinuxSelfContainedArtifactsExists")
     .Does(() =>
 {
-    // This task requires `linuxPackageFeedsDir` to contain scripts from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source.
+    // This task requires `linuxPackageFeedsDir` to contain scripts from https://github.com/OctopusDeploy/linux-package-feeds.
     // They are currently added as an Artifact Dependency in TeamCity from "Infrastructure / Linux Package Feeds"
     //   with the rule: LinuxPackageFeedsTools.*.zip!*=>linux-package-feeds
     // See https://build.octopushq.com/admin/editDependencies.html?id=buildType:OctopusDeploy_OctopusCLI_BuildLinuxContainer

--- a/build.cake
+++ b/build.cake
@@ -343,7 +343,7 @@ Task("CreateLinuxPackages")
     .IsDependentOn("AssertLinuxSelfContainedArtifactsExists")
     .Does(() =>
 {
-    // This task requires `linuxPackageFeedsDir` to contain tools from https://github.com/OctopusDeploy/linux-package-feeds.
+    // This task requires `linuxPackageFeedsDir` to contain scripts from https://github.com/OctopusDeploy/linux-package-feeds/tree/master/source.
     // They are currently added as an Artifact Dependency in TeamCity from "Infrastructure / Linux Package Feeds"
     //   with the rule: LinuxPackageFeedsTools.*.zip!*=>linux-package-feeds
     // See https://build.octopushq.com/admin/editDependencies.html?id=buildType:OctopusDeploy_OctopusCLI_BuildLinuxContainer


### PR DESCRIPTION
This branch includes 6 unrelated minor improvements, mostly defensive coding and expanding upon explanations (after review discussions on OctopusDeploy/OctopusTentacle#201).

It will be easiest to look over each individual commit:

- Remove unused variable
- Increase test hostname specificity
- Add exit code check (no impact, just for convention / defensiveness)
- Fail if the Tentacle test fails, because it's worth being aware of
- Expand error messages to explain where to get linux-package-feeds
- Clarify the purpose of calls out to linux-package-feeds scripts