### PR TITLE
Pass signing secrets through into the package creation process

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -343,10 +343,17 @@ Task("CreateLinuxPackages")
     .IsDependentOn("AssertLinuxSelfContainedArtifactsExists")
     .Does(() =>
 {
-    // This task requires `linuxPackageFeedsDir` to contain scripts from https://github.com/OctopusDeploy/linux-package-feeds.
-    // They are currently added as an Artifact Dependency in TeamCity from "Infrastructure / Linux Package Feeds"
-    //   with the rule: LinuxPackageFeedsTools.*.zip!*=>linux-package-feeds
-    // See https://build.octopushq.com/admin/editDependencies.html?id=buildType:OctopusDeploy_OctopusCLI_BuildLinuxContainer
+    if (string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PRIVATE_KEY"))
+        || string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PASSPHRASE")) {
+        throw new Exception("This build requires environment variables `SIGN_PRIVATE_KEY` (in a format gpg1 can import)"
+            + " and `SIGN_PASSPHRASE`, which are used to sign the .rpm.");
+    }
+    if (!context.DirectoryExists(linuxPackageFeedsDir)) {
+        throw new Exception($"This build requires `{linuxPackageFeedsDir}` to contain scripts from https://github.com/OctopusDeploy/linux-package-feeds.\n"
+            + "They are usually added as an Artifact Dependency in TeamCity from 'Infrastructure / Linux Package Feeds' with the rule:\n"
+            + "  LinuxPackageFeedsTools.*.zip!*=>linux-package-feeds\n"
+            + "See https://build.octopushq.com/admin/editDependencies.html?id=buildType:OctopusDeploy_OctopusCLI_BuildLinuxContainer");
+    }
 
     UnTarGZip(
         artifactsDir + $"/OctopusTools.{nugetVersion}.linux-x64.tar.gz",

--- a/build.cake
+++ b/build.cake
@@ -344,7 +344,7 @@ Task("CreateLinuxPackages")
     .Does(() =>
 {
     if (string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PRIVATE_KEY"))
-        || string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PASSPHRASE")) {
+        || string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PASSPHRASE"))) {
         throw new Exception("This build requires environment variables `SIGN_PRIVATE_KEY` (in a format gpg1 can import)"
             + " and `SIGN_PASSPHRASE`, which are used to sign the .rpm.");
     }

--- a/build.cake
+++ b/build.cake
@@ -358,7 +358,9 @@ Task("CreateLinuxPackages")
         Env = new string[] { 
             $"VERSION={nugetVersion}",
             $"BINARIES_PATH=/artifacts/OctopusTools.{nugetVersion}.linux-x64.extracted/",
-            "PACKAGES_PATH=/artifacts"
+            "PACKAGES_PATH=/artifacts",
+            "SIGN_PRIVATE_KEY",
+            "SIGN_PASSPHRASE"
         },
         Volume = new string[] { 
             System.IO.Path.Combine(Environment.CurrentDirectory, assetDir) + ":/BuildAssets",

--- a/build.cake
+++ b/build.cake
@@ -341,7 +341,7 @@ Task("BuildDockerImage")
 
 Task("CreateLinuxPackages")
     .IsDependentOn("AssertLinuxSelfContainedArtifactsExists")
-    .Does(() =>
+    .Does(context =>
 {
     if (string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PRIVATE_KEY"))
         || string.IsNullOrEmpty(context.EnvironmentVariable("SIGN_PASSPHRASE"))) {


### PR DESCRIPTION
This passes environment variables SIGN_PRIVATE_KEY and SIGN_PASSPHRASE from the outside environment (usually TeamCity) through to the package creation process, to support OctopusDeploy/linux-package-feeds#1.