### PR TITLE
Remove compatibility check now that tentacle is available with focal sources

### DIFF
--- a/BuildAssets/repos/test-linux-package-from-feed.sh
+++ b/BuildAssets/repos/test-linux-package-from-feed.sh
@@ -28,10 +28,6 @@ fi
 
 # Install the packages from our package feed (with any needed docker config, system registration) using a script from 'linux-package-feeds'.
 export PKG_NAMES="octopuscli tentacle"
-# TODO: (ZZDY) Remove this workaround once tentacle is added to focal repo
-if grep --quiet focal /etc/apt/sources.list 2>/dev/null; then
-  PKG_NAMES="octopuscli"
-fi
 bash /opt/linux-package-feeds/install-linux-feed-package.sh || exit
 
 if command -v dpkg > /dev/null; then
@@ -44,9 +40,6 @@ echo Testing octo.
 octo version || exit
 OCTO_RESULT="$(octo list-environments --space="$OCTOPUS_SPACE")" || { echo "$OCTO_RESULT"; exit 1; }
 echo "$OCTO_RESULT" | grep "$OCTOPUS_EXPECT_ENV" || { echo "Expected environment not found: $OCTOPUS_EXPECT_ENV." >&2; exit 1; }
-
-# TODO: (ZZDY) Remove this workaround once tentacle is added to focal repo
-if [[ ! "$PKG_NAMES" == *tentacle ]]; then exit 0; fi
 
 echo Testing tentacle.
 /opt/octopus/tentacle/Tentacle version || exit


### PR DESCRIPTION
# Background

The Octopus CLI linux package deployment process includes a secondary smoke check to confirm we haven't just broken Tentacle, which shares the same APT and RPM repos.

We had a workaround in place to skip that check on Ubuntu `focal`, as Tentacle had not shipped with its dist specifier yet.

# Change

Now that Tentacle is shipped specifically with the `focal` dist specifier, the workaround can go away.