### PR TITLE
Create release from git reference

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -307,11 +307,17 @@ namespace Octo.Tests.Commands
         }
 
         [Test]
-        public void VersionControlledProject_ShouldGitReference()
+        public void VersionControlledProject_WithGitReference_ShouldBeViablePlan()
         {
             gitReference = "main";
             projectResource.IsVersionControlled = true;
+            var deploymentStepResource = ResourceBuilderHelpers.GetStep();
+            deploymentStepResource.Actions.Add(ResourceBuilderHelpers.GetAction().WithChannel(channelResource.Id));
+            deploymentProcessResource.Steps.Add(deploymentStepResource);
+
             var plan = ExecuteBuild();
+
+            plan.IsViableReleasePlan().Should().BeTrue();
         }
 
         [Test]

--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Cli.Commands.Releases;
+using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Model;
 using Octopus.Cli.Util;
 using Octopus.Client;
@@ -24,6 +25,7 @@ namespace Octo.Tests.Commands
         private IChannelVersionRuleTester versionRuleTester;
         private IOctopusAsyncRepository repository;
         private IDeploymentProcessRepository deploymentProcessRepository;
+        private IDeploymentProcessRepositoryBeta deploymentProcessRepositoryBeta;
         private IReleaseRepository releaseRepository;
         private IFeedRepository feedRepository;
         private ICommandOutputProvider commandOutputProvider;
@@ -37,6 +39,7 @@ namespace Octo.Tests.Commands
         private ChannelVersionRuleTestResult channelVersionRuleTestResult = new ChannelVersionRuleTestResult();
         private FeedResource feedResource;
         private List<PackageResource> packages = new List<PackageResource>();
+        private string gitReference;
 
         [SetUp]
         public void Setup()
@@ -89,18 +92,24 @@ namespace Octo.Tests.Commands
                 .Test(Arg.Any<IOctopusAsyncRepository>(), Arg.Any<ChannelVersionRuleResource>(), Arg.Any<string>())
                 .Returns(Task.FromResult(channelVersionRuleTestResult));
 
+            deploymentProcessRepositoryBeta = Substitute.For<IDeploymentProcessRepositoryBeta>();
+            deploymentProcessRepositoryBeta.Get(projectResource, Arg.Any<string>())
+                .Returns(Task.FromResult(deploymentProcessResource));
+
             releaseRepository = Substitute.For<IReleaseRepository>();
             feedRepository = Substitute.For<IFeedRepository>();
             feedRepository.Get(Arg.Any<string>()).Returns(feedResource);
 
             repository = Substitute.For<IOctopusAsyncRepository>();
             repository.DeploymentProcesses.Returns(deploymentProcessRepository);
+            repository.DeploymentProcesses.Beta().Returns(deploymentProcessRepositoryBeta);
             repository.Releases.Returns(releaseRepository);
             repository.Feeds.Returns(feedRepository);
             repository.Client
                 .Get<List<PackageResource>>(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>()).Returns(packages);
 
             builder = new ReleasePlanBuilder(logger, versionResolver, versionRuleTester, commandOutputProvider);
+            gitReference = null;
         }
 
         [Test]
@@ -183,7 +192,7 @@ namespace Octo.Tests.Commands
             deploymentProcessResource.Steps.Add(deploymentStepResource);
 
             releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage().WithVersion("1.0.0", versionResolver));
-            channelVersionRuleTestResult.IsSatified();
+            channelVersionRuleTestResult.IsSatisfied();
 
 
             // act
@@ -277,7 +286,7 @@ namespace Octo.Tests.Commands
             packages.Add(new PackageResource { Version = "1.0.1"});
 
             releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true});
-            channelVersionRuleTestResult.IsSatified();
+            channelVersionRuleTestResult.IsSatisfied();
             
             repository.Client
                 .Get<List<PackageResource>>(Arg.Any<string>(), Arg.Is<IDictionary<string, object>>(d => d.ContainsKey("versionRange") && (string)d["versionRange"] == "(,1.0)")).Returns(new List<PackageResource>());
@@ -287,6 +296,31 @@ namespace Octo.Tests.Commands
 
             // assert
             plan.IsViableReleasePlan().Should().BeFalse();
+        }
+
+        [Test]
+        public void VersionedControlledProject_ShouldRequireGitReference()
+        {
+            projectResource.IsVersionControlled = true;
+            var ex = Assert.ThrowsAsync<CommandException>(ExecuteBuildAsync);
+            ex.Message.Should().Be(ReleasePlanBuilder.GitReferenceMissingForVersionControlledProjectErrorMessage);
+        }
+
+        [Test]
+        public void VersionControlledProject_ShouldGitReference()
+        {
+            gitReference = "main";
+            projectResource.IsVersionControlled = true;
+            var plan = ExecuteBuild();
+        }
+
+        [Test]
+        public void DatabaseProject_ShouldRejectGitReference()
+        {
+            projectResource.IsVersionControlled = false;
+            gitReference = "main";
+            var ex = Assert.ThrowsAsync<CommandException>(ExecuteBuildAsync);
+            ex.Message.Should().Be(ReleasePlanBuilder.GitReferenceSuppliedForDatabaseProjectErrorMessage(gitReference));
         }
 
         private static ReleaseTemplatePackage GetReleaseTemplatePackage()
@@ -305,7 +339,7 @@ namespace Octo.Tests.Commands
 
         private async Task<ReleasePlan> ExecuteBuildAsync()
         {
-            return await builder.Build(repository, projectResource, channelResource, versionPreReleaseTag: string.Empty);
+            return await builder.Build(repository, projectResource, channelResource, string.Empty, gitReference);
         }
     }
 
@@ -358,7 +392,7 @@ namespace Octo.Tests.Commands
             return releaseTemplatePackage;
         }
 
-        public static ChannelVersionRuleTestResult IsSatified(this ChannelVersionRuleTestResult versionRuleTestResult)
+        public static ChannelVersionRuleTestResult IsSatisfied(this ChannelVersionRuleTestResult versionRuleTestResult)
         {
             versionRuleTestResult.SatisfiesPreReleaseTag = true;
             versionRuleTestResult.SatisfiesVersionRange = true;

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="8.8.2" />
+    <PackageReference Include="Octopus.Client" Version="8.8.7" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -29,7 +29,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="8.8.7" />
+    <PackageReference Include="Octopus.Client" Version="8.8.8" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -183,6 +183,10 @@ namespace Octopus.Cli.Commands.Releases
                     .ConfigureAwait(false);
 
                 commandOutputProvider.Information("Release {Version:l} created successfully!", release.Version);
+                if (!string.IsNullOrEmpty(release.VersionControlReference.GitCommit))
+                {
+                    commandOutputProvider.Information("Release created from commit {Commit:l} of git reference {GitRef:l}.", release.VersionControlReference.GitCommit, release.VersionControlReference.GitRef);
+                }
                 commandOutputProvider.ServiceMessage("setParameter", new { name = "octo.releaseNumber", value = release.Version });
                 commandOutputProvider.TfsServiceMessage(ServerBaseUrl, project, release);
 

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -183,7 +183,7 @@ namespace Octopus.Cli.Commands.Releases
                     .ConfigureAwait(false);
 
                 commandOutputProvider.Information("Release {Version:l} created successfully!", release.Version);
-                if (!string.IsNullOrEmpty(release.VersionControlReference.GitCommit))
+                if (!string.IsNullOrEmpty(release.VersionControlReference?.GitCommit))
                 {
                     commandOutputProvider.Information("Release created from commit {Commit:l} of git reference {GitRef:l}.", release.VersionControlReference.GitCommit, release.VersionControlReference.GitRef);
                 }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -175,7 +175,7 @@ namespace Octopus.Cli.Commands.Releases
                     {
                         ReleaseNotes = ReleaseNotes,
                         SelectedPackages = plan.GetSelections(),
-                        VersionControlReferenceResource = new VersionControlReferenceResource
+                        VersionControlReference = new VersionControlReferenceResource
                         {
                             GitRef = GitReference
                         }

--- a/source/Octopus.Cli/Commands/Releases/IReleasePlanBuilder.cs
+++ b/source/Octopus.Cli/Commands/Releases/IReleasePlanBuilder.cs
@@ -6,6 +6,6 @@ namespace Octopus.Cli.Commands.Releases
 {
     public interface IReleasePlanBuilder
     {
-        Task<ReleasePlan> Build(IOctopusAsyncRepository repository, ProjectResource project, ChannelResource channel, string versionPreReleaseTag);
+        Task<ReleasePlan> Build(IOctopusAsyncRepository repository, ProjectResource project, ChannelResource channel, string versionPreReleaseTag, string gitReference);
     }
 }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="8.8.2" />
+    <PackageReference Include="Octopus.Client" Version="8.8.7" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />
@@ -45,6 +45,6 @@
   	<DefineConstants>NETFRAMEWORK</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="icon.png" Pack="true" PackagePath="\"/>
+    <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="8.8.7" />
+    <PackageReference Include="Octopus.Client" Version="8.8.8" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />


### PR DESCRIPTION
This PR adds the `--gitRef` parameter to the `create-release` command to enable creating release for version controlled projects from a git reference.

Example usage:

`create-release --server http://localhost:8065 --project  "Config as Code" --gitRef main`

Sample output:

```
Detected automation environment: "NoneOrUnknown"
Handshaking with Octopus Server: http://localhost:8065
Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
Authenticated as: admin
Found environments:
This Octopus Server supports channels
Found project: Config as Code (Projects-201)
Automatically selecting the best channel for this release...
Building a release plan for Channel 'Default'...
Finding deployment process at git reference main...
Finding release template at git reference main...
Selected the release plan for Channel 'Default' - it is a perfect match
Using version number from release template: 0.0.11
Release plan for CAC 0.0.11
Channel: 'Default' (this is the default channel)

Creating release...
Release 0.0.11 created successfully!
```