### PR TITLE
Show git commit and reference when listing releases

### DIFF
--- a/source/Octo.Tests/Commands/ListReleasesCommandFixture.JsonFormat_ShouldBeWellFormed.approved.txt
+++ b/source/Octo.Tests/Commands/ListReleasesCommandFixture.JsonFormat_ShouldBeWellFormed.approved.txt
@@ -1,0 +1,49 @@
+[
+  {
+    "Project": {
+      "Id": "projectaid",
+      "Name": "ProjectA"
+    },
+    "Releases": [
+      {
+        "Version": "1.0",
+        "Assembled": "0001-01-01T00:00:00.000+00:00",
+        "PackageVersions": "",
+        "ReleaseNotes": "Release Notes 1",
+        "GitReference": null,
+        "GitCommit": null
+      },
+      {
+        "Version": "2.0",
+        "Assembled": "9999-12-31T23:59:59.999+00:00",
+        "PackageVersions": "",
+        "ReleaseNotes": "Release Notes 2",
+        "GitReference": null,
+        "GitCommit": null
+      }
+    ]
+  },
+  {
+    "Project": {
+      "Id": "projectbid",
+      "Name": "ProjectB"
+    },
+    "Releases": []
+  },
+  {
+    "Project": {
+      "Id": "Projects-3",
+      "Name": "Version controlled project"
+    },
+    "Releases": [
+      {
+        "Version": "1.2.3",
+        "Assembled": "9999-12-31T23:59:59.999+00:00",
+        "PackageVersions": "",
+        "ReleaseNotes": "Version controlled release notes",
+        "GitReference": "main",
+        "GitCommit": "87a072ad2b4a2e9bf2d7ff84d8636a032786394d"
+      }
+    ]
+  }
+]

--- a/source/Octo.Tests/Commands/ListReleasesCommandFixture.ShouldGetListOfReleases.approved.txt
+++ b/source/Octo.Tests/Commands/ListReleasesCommandFixture.ShouldGetListOfReleases.approved.txt
@@ -1,0 +1,23 @@
+Octopus Deploy Command Line Tool, version <VERSION>
+
+Releases: 3
+ - Project: ProjectA
+    Version: 1.0
+    Assembled: <ASSEMBLED-TIMESTAMP>
+    Package Versions: Deploy a package 1.0
+    Release Notes: Release Notes 1
+
+    Version: 2.0
+    Assembled: <ASSEMBLED-TIMESTAMP>
+    Package Versions: 
+    Release Notes: Release Notes 2
+
+ - Project: ProjectB
+ - Project: Version controlled project
+    Version: 1.2.3
+    Assembled: <ASSEMBLED-TIMESTAMP>
+    Package Versions: 
+    Release Notes: Version controlled release notes
+    Git Reference: main
+    Git Commit: 87a072ad2b4a2e9bf2d7ff84d8636a032786394d
+

--- a/source/Octo.Tests/Helpers/ApprovalScrubberExtensions.cs
+++ b/source/Octo.Tests/Helpers/ApprovalScrubberExtensions.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+
+namespace Octopus.Cli.Tests.Helpers
+{
+    public static class ApprovalScrubberExtensions
+    {
+        public static string ScrubApprovalString(this string approval)
+        {
+            return approval.ScrubCliVersion().ScrubAssembledTimestamps();
+        }
+
+        static readonly Regex CliVersionScrubber = new Regex("(?<=Octopus Deploy Command Line Tool, version\\s)[^\\s]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static string ScrubCliVersion(this string subject)
+        {
+            return CliVersionScrubber.Replace(subject, "<VERSION>");
+        }
+
+        static readonly Regex AssembledTimestampScrubber = new Regex(@"Assembled: (?<assembled>.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static string ScrubAssembledTimestamps(this string subject)
+        {
+            foreach (Match m in AssembledTimestampScrubber.Matches(subject))
+            {
+                subject = subject.Replace(m.Groups["assembled"].Value, "<ASSEMBLED-TIMESTAMP>");
+            }
+            return subject;
+        }
+    }
+}

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Assent" Version="1.6.1" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/source/Octopus.Cli/Commands/ApiCommand.cs
+++ b/source/Octopus.Cli/Commands/ApiCommand.cs
@@ -303,13 +303,23 @@ namespace Octopus.Cli.Commands
 
         protected static IEnumerable<string> FormatReleasePropertiesAsStrings(ReleaseResource release)
         {
-            return new List<string>
+            var releaseProperties = new List<string>
             {
                 "Version: " + release.Version,
                 "Assembled: " + release.Assembled,
                 "Package Versions: " + GetPackageVersionsAsString(release.SelectedPackages),
                 "Release Notes: " + GetReleaseNotes(release)
             };
+            if (!string.IsNullOrEmpty(release.VersionControlReference?.GitRef))
+            {
+                releaseProperties.Add("Git Reference: " + release.VersionControlReference.GitRef);
+            }
+            if (!string.IsNullOrEmpty(release.VersionControlReference?.GitCommit))
+            {
+                releaseProperties.Add("Git Commit: " + release.VersionControlReference.GitCommit);
+            }
+
+            return releaseProperties;
         }
 
         protected static string GetReleaseNotes(ReleaseResource release)

--- a/source/Octopus.Cli/Commands/Releases/ListReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/ListReleasesCommand.cs
@@ -77,7 +77,9 @@ namespace Octopus.Cli.Commands.Releases
                     r.Version,
                     r.Assembled,
                     PackageVersions = GetPackageVersionsAsString(r.SelectedPackages),
-                    ReleaseNotes = GetReleaseNotes(r)
+                    ReleaseNotes = GetReleaseNotes(r),
+                    GitReference = r.VersionControlReference?.GitRef,
+                    r.VersionControlReference?.GitCommit
                 })
             }));
         }


### PR DESCRIPTION
This PR adds the reference and commit to `list-releases` output for version controlled projects:

```
- Project: Version controlled project
    Version: 1.2.3
    Assembled: <ASSEMBLED-TIMESTAMP>
    Package Versions: 
    Release Notes: Version controlled release notes
    Git Reference: main
    Git Commit: 87a072ad2b4a2e9bf2d7ff84d8636a032786394d
```