### PR TITLE
Pass feed id when verifying channel rules

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -29,7 +29,7 @@ namespace Octo.Tests.Commands
         private IReleaseRepository releaseRepository;
         private IFeedRepository feedRepository;
         private ICommandOutputProvider commandOutputProvider;
-        
+
         private ProjectResource projectResource;
         private ChannelResource channelResource;
 
@@ -75,7 +75,7 @@ namespace Octo.Tests.Commands
             {
                 Links = new LinkCollection {{"SearchTemplate", TestHelpers.GetId("searchUri")}}
             };
-            
+
             // setup mocks
             logger = Substitute.For<ILogger>();
             versionResolver = Substitute.For<IPackageVersionResolver>();
@@ -89,7 +89,7 @@ namespace Octo.Tests.Commands
                 .GetTemplate(Arg.Is<DeploymentProcessResource>(deploymentProcessResource),
                     Arg.Is<ChannelResource>(channelResource)).Returns(Task.FromResult(releaseTemplateResource));
             versionRuleTester
-                .Test(Arg.Any<IOctopusAsyncRepository>(), Arg.Any<ChannelVersionRuleResource>(), Arg.Any<string>())
+                .Test(Arg.Any<IOctopusAsyncRepository>(), Arg.Any<ChannelVersionRuleResource>(), Arg.Any<string>(), Arg.Any<string>())
                 .Returns(Task.FromResult(channelVersionRuleTestResult));
 
             deploymentProcessRepositoryBeta = Substitute.For<IDeploymentProcessRepositoryBeta>();
@@ -205,7 +205,7 @@ namespace Octo.Tests.Commands
         [Test]
         public void StepWithNoPackageVersion_ShouldNotBeViablePlan()
         {
-            // arrange 
+            // arrange
             releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage()
                 .WithVersion(string.Empty, versionResolver));
 
@@ -224,7 +224,7 @@ namespace Octo.Tests.Commands
 
             // act
             var plan = ExecuteBuild();
-            
+
             // assert
             plan.IsViableReleasePlan().Should().BeFalse();
         }
@@ -282,15 +282,15 @@ namespace Octo.Tests.Commands
                 },
                 VersionRange = "(,1.0)"
             });
-            
+
             packages.Add(new PackageResource { Version = "1.0.1"});
 
             releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true});
             channelVersionRuleTestResult.IsSatisfied();
-            
+
             repository.Client
                 .Get<List<PackageResource>>(Arg.Any<string>(), Arg.Is<IDictionary<string, object>>(d => d.ContainsKey("versionRange") && (string)d["versionRange"] == "(,1.0)")).Returns(new List<PackageResource>());
-            
+
             // act
             var plan = ExecuteBuild();
 

--- a/source/Octopus.Cli/Commands/Releases/ChannelVersionRuleTester.cs
+++ b/source/Octopus.Cli/Commands/Releases/ChannelVersionRuleTester.cs
@@ -8,7 +8,7 @@ namespace Octopus.Cli.Commands.Releases
 {
     public class ChannelVersionRuleTester : IChannelVersionRuleTester
     {
-        public async Task<ChannelVersionRuleTestResult> Test(IOctopusAsyncRepository repository, ChannelVersionRuleResource rule, string packageVersion)
+        public async Task<ChannelVersionRuleTestResult> Test(IOctopusAsyncRepository repository, ChannelVersionRuleResource rule, string packageVersion, string feedId)
         {
             if (rule == null)
             {
@@ -22,7 +22,8 @@ namespace Octopus.Cli.Commands.Releases
             {
                 version = packageVersion,
                 versionRange = rule.VersionRange,
-                preReleaseTag = rule.Tag
+                preReleaseTag = rule.Tag,
+                feedId = feedId
             };
 
             var response = (await repository.LoadRootDocument().ConfigureAwait(false)).UsePostForChannelVersionRuleTest()

--- a/source/Octopus.Cli/Commands/Releases/IChannelVersionRuleTester.cs
+++ b/source/Octopus.Cli/Commands/Releases/IChannelVersionRuleTester.cs
@@ -7,6 +7,6 @@ namespace Octopus.Cli.Commands.Releases
 {
     public interface IChannelVersionRuleTester
     {
-        Task<ChannelVersionRuleTestResult> Test(IOctopusAsyncRepository repository, ChannelVersionRuleResource rule, string packageVersion);
+        Task<ChannelVersionRuleTestResult> Test(IOctopusAsyncRepository repository, ChannelVersionRuleResource rule, string packageVersion, string feedId);
     }
 }

--- a/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
@@ -159,7 +159,7 @@ namespace Octopus.Cli.Commands.Releases
                     var rule = channel.Rules.SingleOrDefault(r => r.ActionPackages.Any(pkg =>
                         pkg.DeploymentActionNameMatches(step.ActionName) &&
                         pkg.PackageReferenceNameMatches(step.PackageReferenceName)));
-                    var result = await versionRuleTester.Test(repository, rule, step.Version).ConfigureAwait(false);
+                    var result = await versionRuleTester.Test(repository, rule, step.Version, step.PackageFeedId).ConfigureAwait(false);
                     step.SetChannelVersionRuleTestResult(result);
                 }
             }
@@ -174,7 +174,7 @@ namespace Octopus.Cli.Commands.Releases
                 return filters;
 
             var rule = channel.Rules.FirstOrDefault(r => r.ActionPackages.Any(pkg => pkg.DeploymentActionNameMatches(stepName) && pkg.PackageReferenceNameMatches(packageReferenceName)));
-            
+
             if (rule == null)
                 return filters;
 


### PR DESCRIPTION
The `/channels/rule-test` endpoint can accept a feed ID (https://github.com/OctopusDeploy/OctopusDeploy/blob/ffcc26ebf15a444ed25633073ac41d45bb99f0d2/source/Octopus.Server/Web/Api/Actions/VersionRuleTestAction.cs#L58) which it uses to build the package version to check against the version range. This change sends the feed id to the endpoint to ensure the package version is correctly generated.