### PR TITLE
Handle feed names in deployment process for cac projects

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -73,6 +73,8 @@ namespace Octo.Tests.Commands
             };
             feedResource = new FeedResource
             {
+                Id = "feeds-builtin",
+                Name = "Built in feed",
                 Links = new LinkCollection {{"SearchTemplate", TestHelpers.GetId("searchUri")}}
             };
 
@@ -96,9 +98,13 @@ namespace Octo.Tests.Commands
             deploymentProcessRepositoryBeta.Get(projectResource, Arg.Any<string>())
                 .Returns(Task.FromResult(deploymentProcessResource));
 
+            var feeds = new List<FeedResource>
+            {
+                feedResource
+            };
             releaseRepository = Substitute.For<IReleaseRepository>();
             feedRepository = Substitute.For<IFeedRepository>();
-            feedRepository.Get(Arg.Any<string>()).Returns(feedResource);
+            feedRepository.Get(Arg.Any<string[]>()).Returns(feeds);
 
             repository = Substitute.For<IOctopusAsyncRepository>();
             repository.DeploymentProcesses.Returns(deploymentProcessRepository);
@@ -283,9 +289,9 @@ namespace Octo.Tests.Commands
                 VersionRange = "(,1.0)"
             });
 
-            packages.Add(new PackageResource { Version = "1.0.1"});
+            packages.Add(new PackageResource { Version = "1.0.1" });
 
-            releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true});
+            releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true, FeedId = "feeds-builtin" });
             channelVersionRuleTestResult.IsSatisfied();
 
             repository.Client
@@ -372,7 +378,7 @@ namespace Octo.Tests.Commands
         public static ReleaseTemplatePackage WithPackage(this ReleaseTemplatePackage releaseTemplatePackage)
         {
             releaseTemplatePackage.PackageId = TestHelpers.GetId("package");
-            releaseTemplatePackage.FeedId = TestHelpers.GetId("feed");
+            releaseTemplatePackage.FeedId = "feeds-builtin";
             return releaseTemplatePackage;
         }
 

--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -41,6 +41,8 @@ namespace Octo.Tests.Commands
         private List<PackageResource> packages = new List<PackageResource>();
         private string gitReference;
 
+        public const string BuiltInFeedId = "feeds-builtin";
+
         [SetUp]
         public void Setup()
         {
@@ -73,7 +75,7 @@ namespace Octo.Tests.Commands
             };
             feedResource = new FeedResource
             {
-                Id = "feeds-builtin",
+                Id = BuiltInFeedId,
                 Name = "Built in feed",
                 Links = new LinkCollection {{"SearchTemplate", TestHelpers.GetId("searchUri")}}
             };
@@ -277,7 +279,7 @@ namespace Octo.Tests.Commands
             // arrange
             var deploymentStepResource = ResourceBuilderHelpers.GetStep();
             var action = ResourceBuilderHelpers.GetAction();
-            action.Packages.Add(new PackageReference("Acme", "Acme", "feeds-builtin", PackageAcquisitionLocation.Server));
+            action.Packages.Add(new PackageReference("Acme", "Acme", BuiltInFeedId, PackageAcquisitionLocation.Server));
             deploymentStepResource.Actions.Add(action);
             deploymentProcessResource.Steps.Add(deploymentStepResource);
             channelResource.AddRule(new ChannelVersionRuleResource
@@ -291,7 +293,7 @@ namespace Octo.Tests.Commands
 
             packages.Add(new PackageResource { Version = "1.0.1" });
 
-            releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true, FeedId = "feeds-builtin" });
+            releaseTemplateResource.Packages.Add(new ReleaseTemplatePackage{ActionName = action.Name, PackageReferenceName = "Acme", IsResolvable = true, FeedId = BuiltInFeedId });
             channelVersionRuleTestResult.IsSatisfied();
 
             repository.Client
@@ -378,7 +380,7 @@ namespace Octo.Tests.Commands
         public static ReleaseTemplatePackage WithPackage(this ReleaseTemplatePackage releaseTemplatePackage)
         {
             releaseTemplatePackage.PackageId = TestHelpers.GetId("package");
-            releaseTemplatePackage.FeedId = "feeds-builtin";
+            releaseTemplatePackage.FeedId = ReleasePlanBuilderTests.BuiltInFeedId;
             return releaseTemplatePackage;
         }
 


### PR DESCRIPTION
Feeds in a deployment processes may be referenced by name or id depending on whether the project is version controlled or not. This PR looks up feeds by the appropriate key when creating a release.