### PR TITLE
Add net50 target

### DIFF
--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -6,7 +6,7 @@
     We include all possible targets here so that no matter what framework version
     the user has installed, there is an appropriate build in the tools package
     -->
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net50</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     <PackageId>Octopus.DotNet.Cli</PackageId>


### PR DESCRIPTION
How I tested:
```
.\build.ps1 -Target CopyToLocalPackages
```
this will produce $artifacts folder.
```
 docker run -t --rm -v ${arifacts}:/nupk -w /work  mcr.microsoft.com/dotnet/sdk:5.0.101-alpine3.12 sh -c 'dotnet tool install --global --add-source /nupk/ Octopus.DotNet.Cli  && export PATH="$PATH":/root/.dotnet/tools &&  dotnet-octo --version'
```
It results in the expected output - 7.4.4 