### PR TITLE
Allow new release versions in CLI commands

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -142,7 +142,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp2.1" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
+        Framework = "netcoreapp2.0" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")

--- a/build.cake
+++ b/build.cake
@@ -409,7 +409,7 @@ private void SignBinaries(string path)
 
 	Sign(files, new SignToolSignSettings {
 			ToolPath = MakeAbsolute(File("./certificates/signtool.exe")),
-            TimeStampUri = new Uri("http://timestamp.verisign.com/scripts/timstamp.dll"),
+            TimeStampUri = new Uri("http://timestamp.digicert.com"),
             CertPath = signingCertificatePath,
             Password = signingCertificatePassword
     });

--- a/build.cake
+++ b/build.cake
@@ -142,7 +142,7 @@ Task("DotnetPublish")
     var portablePublishDir =  $"{octoPublishFolder}/portable";
     DotNetCorePublish(projectToPublish, new DotNetCorePublishSettings
     {
-        Framework = "netcoreapp2.0" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
+        Framework = "netcoreapp2.1" /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */,
         Configuration = configuration,
         OutputDirectory = portablePublishDir,
         ArgumentCustomization = args => args.Append($"/p:Version={nugetVersion}")

--- a/source/Octo.Tests/Commands/AllowReleaseProgressionCommandFixture.cs
+++ b/source/Octo.Tests/Commands/AllowReleaseProgressionCommandFixture.cs
@@ -96,9 +96,7 @@ namespace Octo.Tests.Commands
                 .WithMessage("Please specify a release version number using the version parameter: --version=1.0.5");
         }
 
-        [TestCase("abcdef666")]
-        [TestCase("a.23.c")]
-        [TestCase("1.f.b")]
+        [TestCase("9999999999999999999999999999999999999"), Description("Version number larger than an int")]
         public void ShouldValidateReleaseVersionNumberParameterForFormat(string releaseVersionNumber)
         {
             CommandLineArgs.Add($"--project={projectResource.Name}");
@@ -106,7 +104,7 @@ namespace Octo.Tests.Commands
 
             Func<Task> exec = () => allowReleaseProgressionCommand.Execute(CommandLineArgs.ToArray());
             exec.ShouldThrow<CommandException>()
-                .WithMessage("Please provide a valid release version format, you can refer to https://semver.org/ for a valid format: --version=1.0.5");
+                .WithMessage("Please provide a valid release version format: --version=1.0.5");
         }
 
         [TestCase("version")]

--- a/source/Octo.Tests/Commands/ListDeploymentsCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ListDeploymentsCommandFixture.cs
@@ -29,14 +29,16 @@ namespace Octo.Tests.Commands
                         Name = "",
                         Id = "deploymentid1",
                         ProjectId = "projectaid",
-                        EnvironmentId = "environmentid1"
+                        EnvironmentId = "environmentid1",
+                        ReleaseId = "Release1"
                     },
                     new DeploymentResource
                     {
                         Name = "",
                         Id = "deploymentid2",
                         ProjectId = "projectbid",
-                        EnvironmentId = "environmentid2"
+                        EnvironmentId = "environmentid2",
+                        ReleaseId = "Release2"
                     },
                 }, new LinkCollection());
 
@@ -69,7 +71,8 @@ namespace Octo.Tests.Commands
             Repository.Tenants.FindAll()
                 .Returns(Task.FromResult(new List<TenantResource>()));
 
-            Repository.Releases.Get(Arg.Any<string>()).ReturnsForAnyArgs(new ReleaseResource { Version = "0.0.1" });
+            Repository.Releases.Get(Arg.Is("Release1")).Returns(new ReleaseResource { Version = "0.0.1" });
+            Repository.Releases.Get(Arg.Is("Release2")).Returns(new ReleaseResource { Version = "somedockertag" });
         }
 
         [Test]
@@ -97,6 +100,8 @@ namespace Octo.Tests.Commands
             JsonConvert.DeserializeObject(logoutput);
             logoutput.Should().Contain("ProjectA");
             logoutput.Should().Contain("ProjectB");
+            logoutput.Should().Contain("0.0.1");
+            logoutput.Should().Contain("somedockertag");
         }
     }
 }

--- a/source/Octo.Tests/Commands/ListLatestDeploymentsCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ListLatestDeploymentsCommandFixture.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -6,7 +5,6 @@ using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
 using Octopus.Cli.Commands.Deployment;
-using Octopus.Client.Extensibility;
 using Octopus.Client.Model;
 
 namespace Octo.Tests.Commands
@@ -29,13 +27,15 @@ namespace Octo.Tests.Commands
                     {
                         EnvironmentId = "environmentid1",
                         ProjectId = "projectaid",
-                        TenantId = "tenantid1"                        
+                        TenantId = "tenantid1",
+                        ReleaseId = "Release1"
                     },
                     new DashboardItemResource
                     {
                         EnvironmentId = "environmentid1",
                         ProjectId = "projectaid",
-                        TenantId = "tenantid2"                        
+                        TenantId = "tenantid2",
+                        ReleaseId = "Release2"
                     }
                 },
                 Tenants = new List<DashboardTenantResource>
@@ -62,7 +62,8 @@ namespace Octo.Tests.Commands
                         new EnvironmentResource {Name = "EnvA", Id = "environmentid1"}
                     }));
 
-            Repository.Releases.Get(Arg.Any<string>()).ReturnsForAnyArgs(new ReleaseResource { Version = "0.0.1" });
+            Repository.Releases.Get(Arg.Is("Release1")).Returns(new ReleaseResource { Version = "0.0.1" });
+            Repository.Releases.Get(Arg.Is("Release2")).Returns(new ReleaseResource { Version = "V1.0.0" });
 
             Repository.Dashboards.GetDynamicDashboard(Arg.Any<string[]>(), Arg.Any<string[]>()).ReturnsForAnyArgs(dashboardResources);
         }
@@ -76,6 +77,7 @@ namespace Octo.Tests.Commands
 
             LogLines.Should().Contain(" - Tenant: tenant1");
             LogLines.Should().Contain(" - Tenant: <Removed>");
+            LogLines.Should().Contain("   Version: V1.0.0");
         }
 
         [Test]
@@ -90,6 +92,7 @@ namespace Octo.Tests.Commands
             JsonConvert.DeserializeObject(logoutput);
             logoutput.Should().Contain("tenant1");
             logoutput.Should().Contain("<Removed>");
+            logoutput.Should().Contain("V1.0.0");
         }
     }
 }

--- a/source/Octo.Tests/Commands/ListReleasesCommandFixture.JsonFormat_ShouldBeWellFormed.approved.txt
+++ b/source/Octo.Tests/Commands/ListReleasesCommandFixture.JsonFormat_ShouldBeWellFormed.approved.txt
@@ -20,6 +20,14 @@
         "ReleaseNotes": "Release Notes 2",
         "GitReference": null,
         "GitCommit": null
+      },
+      {
+        "Version": "whateverdockerversion",
+        "Assembled": "9999-12-31T23:59:59.999+00:00",
+        "PackageVersions": "",
+        "ReleaseNotes": "Release Notes 3",
+        "GitReference": null,
+        "GitCommit": null
       }
     ]
   },

--- a/source/Octo.Tests/Commands/ListReleasesCommandFixture.ShouldGetListOfReleases.approved.txt
+++ b/source/Octo.Tests/Commands/ListReleasesCommandFixture.ShouldGetListOfReleases.approved.txt
@@ -1,6 +1,6 @@
 Octopus Deploy Command Line Tool, version <VERSION>
 
-Releases: 3
+Releases: 4
  - Project: ProjectA
     Version: 1.0
     Assembled: <ASSEMBLED-TIMESTAMP>
@@ -11,6 +11,11 @@ Releases: 3
     Assembled: <ASSEMBLED-TIMESTAMP>
     Package Versions: 
     Release Notes: Release Notes 2
+
+    Version: whateverdockerversion
+    Assembled: <ASSEMBLED-TIMESTAMP>
+    Package Versions: 
+    Release Notes: Release Notes 3
 
  - Project: ProjectB
  - Project: Version controlled project

--- a/source/Octo.Tests/Commands/ListReleasesCommandFixture.cs
+++ b/source/Octo.Tests/Commands/ListReleasesCommandFixture.cs
@@ -57,6 +57,13 @@ namespace Octo.Tests.Commands
                 },
                 new ReleaseResource
                 {
+                    ProjectId = "projectaid",
+                    Version = "whateverdockerversion",
+                    Assembled = DateTimeOffset.MaxValue,
+                    ReleaseNotes = "Release Notes 3"
+                },
+                new ReleaseResource
+                {
                     ProjectId = VersionControlledProjectId,
                     Version = "1.2.3",
                     Assembled = DateTimeOffset.MaxValue,
@@ -101,6 +108,13 @@ namespace Octo.Tests.Commands
                     Version = "2.0",
                     Assembled = DateTimeOffset.MaxValue,
                     ReleaseNotes = "Release Notes 2"
+                },
+                new ReleaseResource
+                {
+                    ProjectId = "projectaid",
+                    Version = "whateverdockerversion",
+                    Assembled = DateTimeOffset.MaxValue,
+                    ReleaseNotes = "Release Notes 3"
                 },
                 new ReleaseResource
                 {

--- a/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverFixture.cs
@@ -24,44 +24,49 @@ namespace Octo.Tests.Commands
             resolver = new PackageVersionResolver(log, fileSystem);
         }
 
-        [Test]
-        public void ShouldReturnPackageVersionToUse()
+        [TestCase("1.0.0", "1.1.0")]
+        [TestCase("v1.0.0", "v1.1.0")]
+        [TestCase("V1.0.0", "somedockertag")]
+        public void ShouldReturnPackageVersionToUse(string version1, string version2)
         {
-            resolver.Add("PackageA", "1.0.0");
-            resolver.Add("PackageB", "1.1.0");
+            resolver.Add("PackageA", version1);
+            resolver.Add("PackageB", version2);
 
-            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo("1.0.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo("1.0.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo("1.0.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageB"), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageB", null), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageB", string.Empty), Is.EqualTo("1.1.0"));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo(version1));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo(version1));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo(version1));
+            Assert.That(resolver.ResolveVersion("Step", "PackageB"), Is.EqualTo(version2));
+            Assert.That(resolver.ResolveVersion("Step", "PackageB", null), Is.EqualTo(version2));
+            Assert.That(resolver.ResolveVersion("Step", "PackageB", string.Empty), Is.EqualTo(version2));
         }
 
-        [Test]
-        public void ShouldBeCaseInsensitive()
+        [TestCase("1.1.0")]
+        [TestCase("v1.1.0")]
+        [TestCase("1.2.3somedockertag")]
+        public void ShouldBeCaseInsensitive(string version)
         {
             resolver.Add("PackageA", "1.0.0");
-            resolver.Add("packageA", "1.1.0");
+            resolver.Add("packageA", version);
 
-            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "packagea"), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "packagea", null), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "packagea", string.Empty), Is.EqualTo("1.1.0"));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo(version));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo(version));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo(version));
+            Assert.That(resolver.ResolveVersion("Step", "packagea"), Is.EqualTo(version));
+            Assert.That(resolver.ResolveVersion("Step", "packagea", null), Is.EqualTo(version));
+            Assert.That(resolver.ResolveVersion("Step", "packagea", string.Empty), Is.EqualTo(version));
         }
 
-        [Test]
-        public void ShouldReturnHighestWhenConflicts()
+        [TestCase("0.9.0", "1.0.0", "1.1.0")]
+        [TestCase("v0.9.0", "V1.0.0", "v1.1.0")]
+        public void ShouldReturnHighestWhenConflicts(string version1, string version2, string version3)
         {
-            resolver.Add("PackageA", "1.0.0");
-            resolver.Add("PackageA", "1.1.0");
-            resolver.Add("PackageA", "0.9.0");
+            resolver.Add("PackageA", version1);
+            resolver.Add("PackageA", version2);
+            resolver.Add("PackageA", version3);
 
-            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo("1.1.0"));
-            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo("1.1.0"));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA"), Is.EqualTo(version3));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", null), Is.EqualTo(version3));
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", string.Empty), Is.EqualTo(version3));
         }
 
         [Test]

--- a/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
+++ b/source/Octo.Tests/Commands/PackageVersionResolverNamedPackagesFixture.cs
@@ -29,6 +29,16 @@ namespace Octo.Tests.Commands
             Assert.That(resolver.ResolveVersion("Step", "PackageA", "Package1"), Is.EqualTo("1.0.0"));
             Assert.That(resolver.ResolveVersion("Step", "PackageB", "Package1"), Is.EqualTo("1.1.0"));
         }
+        
+        [Test]
+        public void ShouldReturnDockerPackageVersionToUse()
+        {
+            resolver.Add("PackageA", "Package1", "iamadockertag");
+            resolver.Add("PackageB", "Package1", "v1.0.0");
+
+            Assert.That(resolver.ResolveVersion("Step", "PackageA", "Package1"), Is.EqualTo("iamadockertag"));
+            Assert.That(resolver.ResolveVersion("Step", "PackageB", "Package1"), Is.EqualTo("v1.0.0"));
+        }
 
         [Test]
         public void ShouldBeCaseInsensitive()

--- a/source/Octo.Tests/Commands/PreventReleaseProgressionCommandFixture.cs
+++ b/source/Octo.Tests/Commands/PreventReleaseProgressionCommandFixture.cs
@@ -113,9 +113,7 @@ namespace Octo.Tests.Commands
                 .WithMessage("Please specify a release version number using the version parameter: --version=1.0.5");
         }
 
-        [TestCase("abc")]
-        [TestCase("a.b.c")]
-        [TestCase("1.3.b")]
+        [TestCase("999999999999999999999999999999999999999999999999999999"), Description("Number larger than an int")]
         public void ShouldValidateReleaseVersionNumberParameterForFormat(string releaseVersionNumber)
         {
             CommandLineArgs.Add($"--project={projectResource.Name}");
@@ -124,7 +122,7 @@ namespace Octo.Tests.Commands
 
             Func<Task> exec = () => preventReleaseProgressionCommand.Execute(CommandLineArgs.ToArray());
             exec.ShouldThrow<CommandException>()
-                .WithMessage("Please provide a valid release version format, you can refer to https://semver.org/ for a valid format: --version=1.0.5");
+                .WithMessage("Please provide a valid release version format: --version=1.0.5");
         }
 
         [TestCase("version")]

--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -192,15 +192,17 @@ namespace Octo.Tests.Commands
             plan.IsViableReleasePlan().Should().BeTrue();
         }
 
-        [Test]
-        public void SinglePackageStep_ShouldBeViablePlan()
+        [TestCase("1.0.0")]
+        [TestCase("v1.0.0")]
+        [TestCase("blah")]
+        public void SinglePackageStep_ShouldBeViablePlan(string version)
         {
             // arrange
             var deploymentStepResource = ResourceBuilderHelpers.GetStep();
             deploymentStepResource.Actions.Add(ResourceBuilderHelpers.GetAction().WithChannel(channelResource.Id).WithPackage());
             deploymentProcessResource.Steps.Add(deploymentStepResource);
 
-            releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage().WithVersion("1.0.0", versionResolver));
+            releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage().WithVersion(version, versionResolver));
             channelVersionRuleTestResult.IsSatisfied();
 
 
@@ -238,8 +240,10 @@ namespace Octo.Tests.Commands
             plan.IsViableReleasePlan().Should().BeFalse();
         }
 
-        [Test]
-        public void MultipleSteps_OneNotResolvable_ShouldNotBeViablePlan()
+        [TestCase("1.0.0")]
+        [TestCase("v1.0.0")]
+        [TestCase("blah")]
+        public void MultipleSteps_OneNotResolvable_ShouldNotBeViablePlan(string version)
         {
             // arrange
             var releaseTemplatePackage = GetReleaseTemplatePackage().WithPackage();
@@ -251,7 +255,7 @@ namespace Octo.Tests.Commands
             releaseTemplateResource.Packages.Add(releaseTemplatePackage);
 
             repository.Client.Get<IList<PackageResource>>(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>())
-                .Returns(new List<PackageResource> {new PackageResource {Version = "1.0.0"}});
+                .Returns(new List<PackageResource> {new PackageResource {Version = version}});
 
             // act
             var plan = ExecuteBuild();

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>

--- a/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
@@ -13,6 +13,7 @@ namespace Octopus.Cli.Commands.Releases
     [Command("allow-releaseprogression", Description = "Allows a release to progress to the next phase.")]
     public class AllowReleaseProgressionCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
         ProjectResource project;
         ReleaseResource release;
 
@@ -32,7 +33,7 @@ namespace Octopus.Cli.Commands.Releases
         {
             if (string.IsNullOrWhiteSpace(ProjectNameOrId)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (string.IsNullOrWhiteSpace(ReleaseVersionNumber)) throw new CommandException("Please specify a release version number using the version parameter: --version=1.0.5");
-
+            if (!OctopusVersionParser.TryParse(ReleaseVersionNumber, out _)) throw new CommandException("Please provide a valid release version format: --version=1.0.5");
             await base.ValidateParameters().ConfigureAwait(false);
         }
 

--- a/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/AllowReleaseProgressionCommand.cs
@@ -6,6 +6,7 @@ using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 
 namespace Octopus.Cli.Commands.Releases
 {
@@ -31,7 +32,6 @@ namespace Octopus.Cli.Commands.Releases
         {
             if (string.IsNullOrWhiteSpace(ProjectNameOrId)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (string.IsNullOrWhiteSpace(ReleaseVersionNumber)) throw new CommandException("Please specify a release version number using the version parameter: --version=1.0.5");
-            if (!SemanticVersion.TryParse(ReleaseVersionNumber, out _)) throw new CommandException("Please provide a valid release version format, you can refer to https://semver.org/ for a valid format: --version=1.0.5");
 
             await base.ValidateParameters().ConfigureAwait(false);
         }

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -8,7 +8,6 @@ using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
 using Octopus.Versioning.Octopus;
-using Serilog;
 
 namespace Octopus.Cli.Commands.Releases
 {

--- a/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/DeleteReleasesCommand.cs
@@ -7,6 +7,7 @@ using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 using Serilog;
 
 namespace Octopus.Cli.Commands.Releases
@@ -14,6 +15,7 @@ namespace Octopus.Cli.Commands.Releases
     [Command("delete-releases", Description = "Deletes a range of releases.")]
     public class DeleteReleasesCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
         ProjectResource project;
         HashSet<string> channels;
         ResourceCollection<ReleaseResource> releases;
@@ -44,8 +46,8 @@ namespace Octopus.Cli.Commands.Releases
             if (string.IsNullOrWhiteSpace(MinVersion)) throw new CommandException("Please specify a minimum version number using the parameter: --minVersion=X.Y.Z");
             if (string.IsNullOrWhiteSpace(MaxVersion)) throw new CommandException("Please specify a maximum version number using the parameter: --maxVersion=X.Y.Z");
 
-            var min = SemanticVersion.Parse(MinVersion);
-            var max = SemanticVersion.Parse(MaxVersion);
+            var min = OctopusVersionParser.Parse(MinVersion);
+            var max = OctopusVersionParser.Parse(MaxVersion);
 
 
             project = await GetProject().ConfigureAwait(false);
@@ -65,8 +67,8 @@ namespace Octopus.Cli.Commands.Releases
                     if (channels.Any() && !channels.Contains(release.ChannelId))
                         continue;
 
-                    var version = SemanticVersion.Parse(release.Version);
-                    if (min > version || version > max)
+                    var version = OctopusVersionParser.Parse(release.Version);
+                    if (min.CompareTo(version) > 0 || version.CompareTo(max) > 0)
                         continue;
 
                     if (WhatIf)

--- a/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
+++ b/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
@@ -8,10 +8,8 @@ using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Util;
-using Octopus.Client.Model;
 using Octopus.Versioning.Octopus;
 using Serilog;
-using SemanticVersion = Octopus.Client.Model.SemanticVersion;
 
 namespace Octopus.Cli.Commands.Releases
 {
@@ -86,7 +84,7 @@ namespace Octopus.Cli.Commands.Releases
         readonly IDictionary<PackageKey, string> stepNameToVersion = new Dictionary<PackageKey, string>(new PackageKey());
         string defaultVersion;
 
-        public PackageVersionResolver(Serilog.ILogger log, IOctopusFileSystem fileSystem)
+        public PackageVersionResolver(ILogger log, IOctopusFileSystem fileSystem)
         {
             this.log = log;
             this.fileSystem = fileSystem;

--- a/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
+++ b/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
@@ -67,7 +67,7 @@ namespace Octopus.Cli.Commands.Releases
     public class PackageVersionResolver : IPackageVersionResolver
     {
         private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
-        
+
         /// <summary>
         /// Used to indicate a match with any matching step name or package reference name
         /// </summary>
@@ -166,7 +166,7 @@ namespace Octopus.Cli.Commands.Releases
                 OctopusVersionParser.Parse(packageVersion);
                 defaultVersion = packageVersion;
             }
-            catch (ArgumentException)
+            catch (Exception)
             {
                 if (packageVersion.Contains(":"))
                 {

--- a/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
+++ b/source/Octopus.Cli/Commands/Releases/PackageVersionResolver.cs
@@ -9,6 +9,7 @@ using NuGet.Versioning;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Util;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 using Serilog;
 using SemanticVersion = Octopus.Client.Model.SemanticVersion;
 
@@ -67,6 +68,8 @@ namespace Octopus.Cli.Commands.Releases
 
     public class PackageVersionResolver : IPackageVersionResolver
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
+        
         /// <summary>
         /// Used to indicate a match with any matching step name or package reference name
         /// </summary>
@@ -147,9 +150,9 @@ namespace Octopus.Cli.Commands.Releases
             var key = new PackageKey(stepNameOrPackageId, packageReferenceName ?? WildCard);
             if (stepNameToVersion.TryGetValue(key, out var current))
             {
-                var newVersion = SemanticVersion.Parse(packageVersion);
-                var currentVersion = SemanticVersion.Parse(current);
-                if (newVersion < currentVersion)
+                var newVersion = OctopusVersionParser.Parse(packageVersion);
+                var currentVersion = OctopusVersionParser.Parse(current);
+                if (newVersion.CompareTo(currentVersion) < 0)
                 {
                     return;
                 }
@@ -162,7 +165,7 @@ namespace Octopus.Cli.Commands.Releases
         {
             try
             {
-                SemanticVersion.Parse(packageVersion);
+                OctopusVersionParser.Parse(packageVersion);
                 defaultVersion = packageVersion;
             }
             catch (ArgumentException)

--- a/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
@@ -6,12 +6,14 @@ using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Exceptions;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 
 namespace Octopus.Cli.Commands.Releases
 {
     [Command("prevent-releaseprogression", Description = "Prevents a release from progressing to the next phase.")]
     public class PreventReleaseProgressionCommand : ApiCommand, ISupportFormattedOutput
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
         ProjectResource project;
         ReleaseResource release;
 
@@ -34,6 +36,7 @@ namespace Octopus.Cli.Commands.Releases
         {
             if (string.IsNullOrWhiteSpace(ProjectNameOrId)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (string.IsNullOrWhiteSpace(ReleaseVersionNumber)) throw new CommandException("Please specify a release version number using the version parameter: --version=1.0.5");
+            if (!OctopusVersionParser.TryParse(ReleaseVersionNumber, out _)) throw new CommandException("Please provide a valid release version format: --version=1.0.5");
             if (string.IsNullOrWhiteSpace(ReasonToPrevent)) throw new CommandException("Please specify a reason why you would like to prevent this release from progressing to next phase using the reason parameter: --reason=Contract Tests Failed");
 
             await base.ValidateParameters().ConfigureAwait(false);

--- a/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PreventReleaseProgressionCommand.cs
@@ -34,7 +34,6 @@ namespace Octopus.Cli.Commands.Releases
         {
             if (string.IsNullOrWhiteSpace(ProjectNameOrId)) throw new CommandException("Please specify a project name or ID using the parameter: --project=XYZ");
             if (string.IsNullOrWhiteSpace(ReleaseVersionNumber)) throw new CommandException("Please specify a release version number using the version parameter: --version=1.0.5");
-            if (!SemanticVersion.TryParse(ReleaseVersionNumber, out _)) throw new CommandException("Please provide a valid release version format, you can refer to https://semver.org/ for a valid format: --version=1.0.5");
             if (string.IsNullOrWhiteSpace(ReasonToPrevent)) throw new CommandException("Please specify a reason why you would like to prevent this release from progressing to next phase using the reason parameter: --reason=Contract Tests Failed");
 
             await base.ValidateParameters().ConfigureAwait(false);

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -1,12 +1,11 @@
-﻿using System.Threading.Tasks;
-using System.Linq;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Octopus.Cli.Commands.Deployment;
 using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Repositories;
 using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
-using Serilog;
-using Octopus.Cli.Commands.Deployment;
 using Octopus.Versioning.Octopus;
 
 namespace Octopus.Cli.Commands.Releases

--- a/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/PromoteReleaseCommand.cs
@@ -7,12 +7,15 @@ using Octopus.Client;
 using Octopus.Client.Model;
 using Serilog;
 using Octopus.Cli.Commands.Deployment;
+using Octopus.Versioning.Octopus;
 
 namespace Octopus.Cli.Commands.Releases
 {
     [Command("promote-release", Description = "Promotes a release.")]
     public class PromoteReleaseCommand : DeploymentCommandBase, ISupportFormattedOutput
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
+        
         ProjectResource project;
         EnvironmentResource environment;
         ReleaseResource release;
@@ -53,7 +56,7 @@ namespace Octopus.Cli.Commands.Releases
             var dashboard = await Repository.Dashboards.GetDynamicDashboard(new[] {project.Id}, new[] {environment.Id}, dashboardItemsOptions).ConfigureAwait(false);
             var dashboardItems = dashboard.Items
                 .Where(e => e.EnvironmentId == environment.Id && e.ProjectId == project.Id)
-                .OrderByDescending(i => SemanticVersion.Parse(i.ReleaseVersion));
+                .OrderByDescending(i => OctopusVersionParser.Parse(i.ReleaseVersion));
 
             var dashboardItem = UseLatestSuccessfulRelease
                 ? dashboardItems.FirstOrDefault(x => x.State == TaskState.Success)

--- a/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
@@ -5,7 +5,6 @@ using System.Text;
 using Octopus.Cli.Infrastructure;
 using Octopus.Client.Model;
 using Octopus.Versioning.Octopus;
-using Serilog;
 
 namespace Octopus.Cli.Commands.Releases
 {

--- a/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Text;
 using Octopus.Cli.Infrastructure;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 using Serilog;
 
 namespace Octopus.Cli.Commands.Releases
 {
     public class ReleasePlan
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
         readonly ReleasePlanItem[] packageSteps;
         private readonly ReleasePlanItem[] scriptSteps;
 
@@ -88,10 +90,10 @@ namespace Octopus.Cli.Commands.Releases
 
         public string GetHighestVersionNumber()
         {
-            var step = PackageSteps.Select(p => SemanticVersion.Parse(p.Version)).OrderByDescending(v => v).FirstOrDefault();
+            var step = PackageSteps.Select(p => OctopusVersionParser.Parse(p.Version)).OrderByDescending(v => v).FirstOrDefault();
             if (step == null)
             {
-                throw new CommandException("None of the deployment packageSteps in this release reference a NuGet package, so the highest package version number cannot be determined.");
+                throw new CommandException("None of the deployment packageSteps in this release reference a package, so the highest package version number cannot be determined.");
             }
 
             return step.ToString();

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Octopus.Client" Version="8.8.8" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0004" />
+    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0005" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0</TargetFrameworks>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>
@@ -36,6 +36,7 @@
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Octopus.Client" Version="8.8.8" />
+    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0001" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.1</TargetFrameworks>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -15,7 +15,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
   </PropertyGroup>
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Octopus.Client" Version="8.8.8" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0005" />
+    <PackageReference Include="Octopus.Versioning" Version="4.3.4" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0</TargetFrameworks>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -15,7 +15,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);HTTP_CLIENT_SUPPORTS_SSL_OPTIONS</DefineConstants>
   </PropertyGroup>
 
@@ -36,7 +36,7 @@
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Octopus.Client" Version="8.8.8" />
-    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0001" />
+    <PackageReference Include="Octopus.Versioning" Version="4.3.4-tryparse0004" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.0.0" />

--- a/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
+++ b/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
@@ -7,7 +7,6 @@ using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
 using Octopus.Versioning.Octopus;
-using Serilog;
 
 namespace Octopus.Cli.Repositories
 {

--- a/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
+++ b/source/Octopus.Cli/Repositories/OctopusRepositoryCommonQueries.cs
@@ -6,12 +6,14 @@ using Octopus.Cli.Infrastructure;
 using Octopus.Cli.Util;
 using Octopus.Client;
 using Octopus.Client.Model;
+using Octopus.Versioning.Octopus;
 using Serilog;
 
 namespace Octopus.Cli.Repositories
 {
     public class OctopusRepositoryCommonQueries
     {
+        private static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
         readonly IOctopusAsyncRepository repository;
         readonly ICommandOutputProvider commandOutputProvider;
 
@@ -60,14 +62,14 @@ namespace Octopus.Cli.Repositories
                 {
                     releaseToPromote = releases
                         .Items // We only need the first page
-                        .OrderByDescending(r => SemanticVersion.Parse(r.Version))
+                        .OrderByDescending(r => OctopusVersionParser.Parse(r.Version))
                         .FirstOrDefault();
                 }
                 else
                 {
                     await releases.Paginate(repository, page =>
                     {
-                        releaseToPromote = Enumerable.OrderByDescending<ReleaseResource, SemanticVersion>(page.Items, r => SemanticVersion.Parse(r.Version))
+                        releaseToPromote = Enumerable.OrderByDescending<ReleaseResource, OctopusVersion>(page.Items, r => OctopusVersionParser.Parse(r.Version))
                             .FirstOrDefault(r => r.ChannelId == channel.Id);
 
                        // If we haven't found one yet, keep paginating


### PR DESCRIPTION
This PR parses release versions as Octopus versions instead of semver to support Docker versioning.