### PR TITLE
Upgrade to nuke 5.1.0

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-source/OctopusCli.sln

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "SigningCertificatePassword": {
+          "type": "string",
+          "description": "Password for the signing certificate"
+        },
+        "SigningCertificatePath": {
+          "type": "string",
+          "description": "Pfx certificate to use for signing the files"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AssertLinuxSelfContainedArtifactsExists",
+              "AssertPortableArtifactsExists",
+              "BuildDockerImage",
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "CreateDockerContainerAndLinuxPackages",
+              "CreateLinuxPackages",
+              "Default",
+              "DotnetPublish",
+              "MergeOctoExe",
+              "PackDotNetOctoNuget",
+              "PackOctopusToolsNuget",
+              "Restore",
+              "Test",
+              "Zip"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AssertLinuxSelfContainedArtifactsExists",
+              "AssertPortableArtifactsExists",
+              "BuildDockerImage",
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "CreateDockerContainerAndLinuxPackages",
+              "CreateLinuxPackages",
+              "Default",
+              "DotnetPublish",
+              "MergeOctoExe",
+              "PackDotNetOctoNuget",
+              "PackOctopusToolsNuget",
+              "Restore",
+              "Test",
+              "Zip"
+            ]
+          }
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "source/OctopusCli.sln"
+}

--- a/build.ps1
+++ b/build.ps1
@@ -29,6 +29,7 @@ $env:DOTNET_MULTILEVEL_LOOKUP = 0
 ###########################################################################
 
 function ExecSafe([scriptblock] $cmd) {
+    $LASTEXITCODE = $null
     & $cmd
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,7 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.tmp"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
@@ -29,7 +29,6 @@ $env:DOTNET_MULTILEVEL_LOOKUP = 0
 ###########################################################################
 
 function ExecSafe([scriptblock] $cmd) {
-    $LASTEXITCODE = $null
     & $cmd
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.tmp"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -365,9 +365,9 @@ class Build : NukeBuild
 
     Target CopyToLocalPackages => _ => _
         .OnlyWhenStatic(() => IsLocalBuild)
-        .DependsOn(PackOctopusToolsNuget)
-        .DependsOn(PackDotNetOctoNuget)
-        .DependsOn(Zip)
+        .TriggeredBy(PackOctopusToolsNuget)
+        .TriggeredBy(PackDotNetOctoNuget)
+        .TriggeredBy(Zip)
         .Executes(() =>
         {
             EnsureExistingDirectory(LocalPackagesDirectory);
@@ -376,7 +376,9 @@ class Build : NukeBuild
         });
 
     Target Default => _ => _
-        .DependsOn(CopyToLocalPackages);
+        .DependsOn(PackOctopusToolsNuget)
+        .DependsOn(PackDotNetOctoNuget)
+        .DependsOn(Zip);
 
     void SignBinaries(string path)
     {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -37,7 +37,7 @@ class Build : NukeBuild
     [Parameter("Pfx certificate to use for signing the files")] readonly AbsolutePath SigningCertificatePath = RootDirectory / "certificates" / "OctopusDevelopment.pfx";
     [Parameter("Password for the signing certificate")] readonly string SigningCertificatePassword = "Password01!";
 
-    [Solution] readonly Solution Solution;
+    [Solution(GenerateProjects = true)] readonly Solution Solution;
 
     [NukeOctoVersion] readonly OctoVersionInfo OctoVersionInfo;
 
@@ -104,10 +104,8 @@ class Build : NukeBuild
         .DependsOn(Test)
         .Executes(() =>
         {
-            var projectToPublish = "./source/Octo/Octo.csproj";
-
             DotNetPublish(_ => _
-                .SetProject(projectToPublish)
+                .SetProject(Solution.Octo)
                 .SetFramework("net452")
                 .SetConfiguration(Configuration)
                 .SetOutput(OctoPublishDirectory / "netfx")
@@ -115,7 +113,7 @@ class Build : NukeBuild
 
             var portablePublishDir = OctoPublishDirectory / "portable";
             DotNetPublish(_ => _
-                .SetProject(projectToPublish)
+                .SetProject(Solution.Octo)
                 .SetFramework("netcoreapp2.0") /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */
                 .SetConfiguration(Configuration)
                 .SetOutput(portablePublishDir)
@@ -127,7 +125,7 @@ class Build : NukeBuild
             CopyFileToDirectory(AssetDirectory / "octo.cmd", portablePublishDir, FileExistsPolicy.Overwrite);
 
             var doc = new XmlDocument();
-            doc.Load(@".\source\Octo\Octo.csproj");
+            doc.Load(Solution.Octo.Path);
             var selectSingleNode = doc.SelectSingleNode("Project/PropertyGroup/RuntimeIdentifiers");
             if (selectSingleNode == null)
                 throw new ApplicationException("Unable to find Project/PropertyGroup/RuntimeIdentifiers in Octo.csproj");
@@ -135,7 +133,7 @@ class Build : NukeBuild
             foreach (var rid in rids.Split(';'))
             {
                 DotNetPublish(_ => _
-                    .SetProject(projectToPublish)
+                    .SetProject(Solution.Octo)
                     .SetConfiguration(Configuration)
                     .SetFramework("netcoreapp3.1")
                     .SetRuntime(rid)

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="ILRepack.Lib" Version="2.0.18" />
-    <PackageReference Include="Nuke.Common" Version="5.0.2" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.289" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.OctoVersion" Version="0.2.453" />
     <PackageReference Include="SharpCompress" Version="0.28.0" />
   </ItemGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.104",
+    "version": "5.0.103",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "5.0.103",
-        "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
+  }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.103",
+    "version": "5.0.104",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
We [upgraded](https://github.com/OctopusDeploy/tool-containers/pull/25) the base build image to install the latest nuke.globaltool (version 5.1.0).
Nuke 5.1.0 [includes a new version](https://github.com/nuke-build/nuke/commit/bef28aab33d202688f67f527f7692b360ba93fa4) of GitVersion.Tool.
This meant we [had to update](https://github.com/OctopusDeploy/tool-containers/pull/25/files#diff-3dc3767944d5097e69dbc20d45548730bb43dfdbde1be7edfdb4140a66c6cfa1R58) the path (LD_LIBRARY_PATH) to the new native tool binaries.
Unfortunately this meant that while new stuff will build, old stuff will not.

As a quick fix, we are updating all projects to nuke 5.1.0 while we ponder the proper fix.

This should have no impact to the builds - if any, it'll be to take it from broken to 💚 