### PR TITLE
Fix tests in fedora:latest

### DIFF
--- a/BuildAssets/test-linux-package.sh
+++ b/BuildAssets/test-linux-package.sh
@@ -33,7 +33,7 @@ if command -v dpkg > /dev/null; then
 fi
 
 if [[ "$OSRELID" == "fedora" ]]; then
-  echo "Fedora detected. Setting BUNDLE_EXTRACTION_BASE_DIR to $(pwd)/dotnet-extraction-dir"
+  echo "Fedora detected. Setting DOTNET_BUNDLE_EXTRACT_BASE_DIR to $(pwd)/dotnet-extraction-dir"
   # to workaround error
   #   realpath(): Operation not permitted
   #   Failure processing application bundle.
@@ -42,7 +42,7 @@ if [[ "$OSRELID" == "fedora" ]]; then
   #   A fatal error was encountered. Could not extract contents of the bundle
 
   mkdir dotnet-extraction-dir
-  export BUNDLE_EXTRACTION_BASE_DIR=$(pwd)/dotnet-extraction-dir
+  export DOTNET_BUNDLE_EXTRACT_BASE_DIR=$(pwd)/dotnet-extraction-dir
 fi
 
 

--- a/BuildAssets/test-linux-package.sh
+++ b/BuildAssets/test-linux-package.sh
@@ -7,6 +7,7 @@ if [[ -z "$OCTOPUS_CLI_SERVER" || -z "$OCTOPUS_CLI_API_KEY" || -z "$OCTOPUS_SPAC
     '\nSpace to search, and an environment name expected to be found there.' >&2
   exit 1
 fi
+
 OSRELID="$(. /etc/os-release && echo $ID)"
 if [[ "$OSRELID" == "rhel" && ( -z "$REDHAT_SUBSCRIPTION_USERNAME" || -z "$REDHAT_SUBSCRIPTION_PASSWORD" ) ]]; then
   echo -e 'This script requires the environment variables REDHAT_SUBSCRIPTION_USERNAME and REDHAT_SUBSCRIPTION_PASSWORD to register'\
@@ -21,9 +22,8 @@ if [[ ! -e /opt/linux-package-feeds ]]; then
   exit 1
 fi
 
-
 # Install the package (with any needed docker config, system registration, dependencies) using a script from 'linux-package-feeds'.
-export PKG_PATH_PREFIX="octopuscli"
+
 bash /opt/linux-package-feeds/install-linux-package.sh || exit
 
 if command -v dpkg > /dev/null; then
@@ -31,6 +31,20 @@ if command -v dpkg > /dev/null; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get --no-install-recommends --yes install ca-certificates >/dev/null || exit
 fi
+
+if [[ "$OSRELID" == "fedora" ]]; then
+  echo "Fedora detected. Setting BUNDLE_EXTRACTION_BASE_DIR to $(pwd)/dotnet-extraction-dir"
+  # to workaround error
+  #   realpath(): Operation not permitted
+  #   Failure processing application bundle.
+  #   Failed to determine location for extracting embedded files
+  #   DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write temp-directory couldn't be created.
+  #   A fatal error was encountered. Could not extract contents of the bundle
+
+  mkdir dotnet-extraction-dir
+  export BUNDLE_EXTRACTION_BASE_DIR=$(pwd)/dotnet-extraction-dir
+fi
+
 
 echo Testing octo.
 octo version || exit

--- a/source/OctopusCli.sln
+++ b/source/OctopusCli.sln
@@ -6,8 +6,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		NuGet.Config = NuGet.Config
 		..\readme.md = ..\readme.md
-		..\BuildAssets\create-linux-packages.sh = ..\BuildAssets\create-linux-packages.sh
 		..\.gitignore = ..\.gitignore
+		..\BuildAssets\create-octopuscli-linux-packages.sh = ..\BuildAssets\create-octopuscli-linux-packages.sh
+		..\BuildAssets\test-linux-package.sh = ..\BuildAssets\test-linux-package.sh
+		..\BuildAssets\test-linux-package-in-dists.sh = ..\BuildAssets\test-linux-package-in-dists.sh
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Octo", "Octo\Octo.csproj", "{D1BFD88F-FB8E-49EC-968F-F4D9A8A52519}"


### PR DESCRIPTION
We started getting issues in our tests from the 29th of April:

```
07:13:10  == Testing in 'fedora:latest' ==
07:12:41  Installing package.
07:13:10  
07:13:10  Installed:
07:13:10    libicu-67.1-6.fc34.x86_64             octopuscli-7.4.3199-1.x86_64
07:13:10  
07:13:10  Testing octo.
07:13:10  realpath(): Operation not permitted
07:13:10  realpath(): Operation not permitted
07:13:10  Failure processing application bundle.
07:13:10  Failed to determine location for extracting embedded files
07:13:10  DOTNET_BUNDLE_EXTRACT_BASE_DIR is not set, and a read-write temp-directory couldn't be created.
07:13:10  A fatal error was encountered. Could not extract contents of the bundle
07:13:11  Process exited with code 159
```

Seems related to https://github.com/dotnet/runtime/issues/47535.

Setting `DOTNET_BUNDLE_EXTRACT_BASE_DIR` seems to make things happier, though it still logs out lots of warnings.

The `realpath` may be [this one](https://github.com/OctopusDeploy/OctopusCLI/blob/master/BuildAssets/test-linux-package-in-dists.sh#L37), but I haven't dug into that