### PR TITLE
Docker base images have moved to mcr.microsoft.com

### DIFF
--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -13,17 +13,14 @@ RUN mkdir /octo &&\
         echo "dotnet /octo/octo.dll \"\$@\"" > /octo/alpine &&\
         ln /octo/alpine /usr/bin/octo &&\
         chmod +x /usr/bin/octo
-        
+
 ARG OCTO_TOOLS_VERSION=4.31.1
 
 LABEL maintainer="devops@octopus.com"
 LABEL octopus.dockerfile.version="1.0"
 LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
-COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz ./tmp/OctopusTools.portable.tar.gz
-
-RUN tar -zxvf /tmp/OctopusTools.portable.tar.gz -C /octo &&\
-	rm /tmp/OctopusTools.portable.tar.gz
+ADD OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz /octo
 
 WORKDIR /src
 ENTRYPOINT ["dotnet", "/octo/octo.dll"]

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,15 +1,12 @@
-FROM microsoft/dotnet:2.1-runtime-nanoserver-sac2016
+FROM mcr.microsoft.com/dotnet/runtime:3.1-nanoserver-20H2
 ARG OCTO_TOOLS_VERSION=4.31.1
 
-LABEL maintainer="devops@octopus.com" 
+LABEL maintainer="devops@octopus.com"
 LABEL octopus.dockerfile.version="1.0"
-LABEL octopus.tools.version=$OCTO_TOOLS_VERSION 
+LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
-COPY OctopusTools.$OCTO_TOOLS_VERSION.portable.zip ./octo/OctopusTools.zip
-
-RUN Expand-Archive ./octo/OctopusTools.zip -DestinationPath octo; \
-	Remove-Item -Force ./octo/OctopusTools.zip; \
-	mkdir src |Out-Null
+COPY Extracted/*.* ./octo/
+RUN "mkdir src"
 
 WORKDIR /src
 ENTRYPOINT ["dotnet", "/octo/octo.dll"]

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="devops@octopus.com"
 LABEL octopus.dockerfile.version="1.0"
 LABEL octopus.tools.version=$OCTO_TOOLS_VERSION
 
-COPY Extracted/*.* ./octo/
+ADD OctopusTools.$OCTO_TOOLS_VERSION.portable.tar.gz ./octo/
 RUN "mkdir src"
 
 WORKDIR /src

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -278,14 +278,15 @@ class Build : NukeBuild
         .DependsOn(AssertPortableArtifactsExists)
         .Executes(() =>
         {
-            var platform = "nanoserver";
-            if (EnvironmentInfo.IsLinux)
-                platform = "alpine";
+            var platform = "alpine";
+            if (EnvironmentInfo.IsWin)
+            {
+                platform = "nanoserver";
+                CompressionTasks.Uncompress(ArtifactsDirectory / $"OctopusTools.{OctoVersionInfo.FullSemVer}.portable.zip", ArtifactsDirectory / "Extracted");
+            }
 
             var tag = $"octopusdeploy/octo-prerelease:{OctoVersionInfo.FullSemVer}-{platform}";
             var latest = $"octopusdeploy/octo-prerelease:latest-{platform}";
-
-            CompressionTasks.Uncompress(ArtifactsDirectory / $"OctopusTools.{OctoVersionInfo.FullSemVer}.portable.zip", ArtifactsDirectory / "Extracted");
 
             DockerTasks.DockerBuild(_ => _
                 .SetFile(RootDirectory / "Dockerfiles" / platform / "Dockerfile")

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -278,12 +278,9 @@ class Build : NukeBuild
         .DependsOn(AssertPortableArtifactsExists)
         .Executes(() =>
         {
-            var platform = "alpine";
-            if (EnvironmentInfo.IsWin)
-            {
-                platform = "nanoserver";
-                CompressionTasks.Uncompress(ArtifactsDirectory / $"OctopusTools.{OctoVersionInfo.FullSemVer}.portable.zip", ArtifactsDirectory / "Extracted");
-            }
+            var platform = "nanoserver";
+            if (EnvironmentInfo.IsLinux)
+                platform = "alpine";
 
             var tag = $"octopusdeploy/octo-prerelease:{OctoVersionInfo.FullSemVer}-{platform}";
             var latest = $"octopusdeploy/octo-prerelease:latest-{platform}";

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -285,6 +285,8 @@ class Build : NukeBuild
             var tag = $"octopusdeploy/octo-prerelease:{OctoVersionInfo.FullSemVer}-{platform}";
             var latest = $"octopusdeploy/octo-prerelease:latest-{platform}";
 
+            CompressionTasks.Uncompress(ArtifactsDirectory / $"OctopusTools.{OctoVersionInfo.FullSemVer}.portable.zip", ArtifactsDirectory / "Extracted");
+
             DockerTasks.DockerBuild(_ => _
                 .SetFile(RootDirectory / "Dockerfiles" / platform / "Dockerfile")
                 .SetTag(tag, latest)


### PR DESCRIPTION
Base image has also changed from `microsoft/dotnet:2.1-runtime-nanoserver-sac2016` to `mcr.microsoft.com/dotnet/runtime:3.1-nanoserver-20H2`, as the old one is being removed, and only newer ones are available.

The dockerfile had to change too, as powershell is no longer installed on the base image.