### PR TITLE
Adding dockerfile for GitLab specific images.

### DIFF
--- a/Dockerfiles/alpine/gitlab.Dockerfile
+++ b/Dockerfiles/alpine/gitlab.Dockerfile
@@ -1,0 +1,3 @@
+FROM octopusdeploy/octo:latest
+
+ENTRYPOINT [""]

--- a/Dockerfiles/nanoserver/gitlab.Dockerfile
+++ b/Dockerfiles/nanoserver/gitlab.Dockerfile
@@ -1,0 +1,3 @@
+FROM octopusdeploy/octo:latest
+
+ENTRYPOINT [""]


### PR DESCRIPTION
GitLab has specific requirements that Docker images not implement ENTRYPOINT.  The Dockerfiles included in this PR implement an empty ENTRYPOINT which is the[ suggested workaround](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/1421) for images that have a default ENTRYPOINT.