### PR TITLE
Support passing a specific release when creating a commit

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -28,7 +28,7 @@ namespace Octo.Tests.Commands
         IChannelVersionRuleTester versionRuleTester;
         IOctopusAsyncRepository repository;
         IDeploymentProcessRepository deploymentProcessRepository;
-        IDeploymentProcessRepositoryBeta deploymentProcessRepositoryBeta;
+        IDeploymentProcessBetaRepository deploymentProcessRepositoryBeta;
         IReleaseRepository releaseRepository;
         IFeedRepository feedRepository;
         ICommandOutputProvider commandOutputProvider;
@@ -96,7 +96,7 @@ namespace Octo.Tests.Commands
                 .Test(Arg.Any<IOctopusAsyncRepository>(), Arg.Any<ChannelVersionRuleResource>(), Arg.Any<string>(), Arg.Any<string>())
                 .Returns(Task.FromResult(channelVersionRuleTestResult));
 
-            deploymentProcessRepositoryBeta = Substitute.For<IDeploymentProcessRepositoryBeta>();
+            deploymentProcessRepositoryBeta = Substitute.For<IDeploymentProcessBetaRepository>();
             deploymentProcessRepositoryBeta.Get(projectResource, Arg.Any<string>())
                 .Returns(Task.FromResult(deploymentProcessResource));
 
@@ -357,7 +357,7 @@ namespace Octo.Tests.Commands
             projectResource.IsVersionControlled = false;
             gitReference = "main";
             var ex = Assert.ThrowsAsync<CommandException>(ExecuteBuildAsync);
-            ex.Message.Should().Be(ReleasePlanBuilder.GitReferenceSuppliedForDatabaseProjectErrorMessage(gitReference));
+            ex.Message.Should().Be(ReleasePlanBuilder.GitReferenceSuppliedForDatabaseProjectErrorMessage($"reference {gitReference}"));
         }
 
         static ReleaseTemplatePackage GetReleaseTemplatePackage()
@@ -380,7 +380,8 @@ namespace Octo.Tests.Commands
                 projectResource,
                 channelResource,
                 string.Empty,
-                gitReference);
+                gitReference,
+                null);
         }
     }
 

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -30,7 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="8.8.8" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3415" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -30,7 +30,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Client" Version="11.3.3415" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3424" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -43,6 +43,7 @@ namespace Octopus.Cli.Commands.Releases
             var options = Options.For("Release creation");
             options.Add<string>("project=", "Name or ID of the project.", v => ProjectNameOrId = v);
             options.Add<string>("defaultPackageVersion=|packageVersion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
+            options.Add<string>("commit=", "[Optional, Experimental] Git commit to use when creating the release. Use in conjunction with the --gitRef parameter.", v => GitCommit = v);
             options.Add<string>("ref=|gitRef=", "[Optional, Experimental] Git reference to use when creating the release.", v => GitReference = v);
             options.Add<string>("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add<string>("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
@@ -67,6 +68,7 @@ namespace Octopus.Cli.Commands.Releases
         }
 
         public string GitReference { get; set; }
+        public string GitCommit { get; set; }
         public string ChannelNameOrId { get; set; }
         public string VersionNumber { get; set; }
         public string ReleaseNotes { get; set; }
@@ -89,8 +91,10 @@ namespace Octopus.Cli.Commands.Releases
             commandOutputProvider.Debug(serverSupportsChannels ? "This Octopus Server supports channels" : "This Octopus Server does not support channels");
 
             project = await Repository.Projects.FindByNameOrIdOrFail(ProjectNameOrId).ConfigureAwait(false);
-
-            plan = await BuildReleasePlan(project).ConfigureAwait(false);
+            
+            ValidateProjectPersistenceRequirements();
+            
+            plan = await BuildReleasePlan().ConfigureAwait(false);
 
             if (!string.IsNullOrWhiteSpace(VersionNumber))
             {
@@ -172,9 +176,7 @@ namespace Octopus.Cli.Commands.Releases
                 // Actually create the release!
                 commandOutputProvider.Debug("Creating release...");
 
-                // if no release notes were provided on the command line, but the project has a template, then use the template
-                if (string.IsNullOrWhiteSpace(ReleaseNotes) && !string.IsNullOrWhiteSpace(project.ReleaseNotesTemplate))
-                    ReleaseNotes = project.ReleaseNotesTemplate;
+                await ReleaseNotesFallBackToDeploymentSettings().ConfigureAwait(false);
 
                 release = await Repository.Releases.Create(new ReleaseResource(versionNumber, project.Id, plan.Channel?.Id)
                         {
@@ -182,7 +184,8 @@ namespace Octopus.Cli.Commands.Releases
                             SelectedPackages = plan.GetSelections(),
                             VersionControlReference = new VersionControlReferenceResource
                             {
-                                GitRef = GitReference
+                                GitRef = GitReference,
+                                GitCommit = GitCommit
                             }
                         },
                         IgnoreChannelRules)
@@ -198,7 +201,7 @@ namespace Octopus.Cli.Commands.Releases
             }
         }
 
-        async Task<ReleasePlan> BuildReleasePlan(ProjectResource project)
+        async Task<ReleasePlan> BuildReleasePlan()
         {
             if (!string.IsNullOrWhiteSpace(ChannelNameOrId))
             {
@@ -209,7 +212,8 @@ namespace Octopus.Cli.Commands.Releases
                         project,
                         matchingChannel,
                         VersionPreReleaseTag,
-                        GitReference)
+                        GitReference,
+                        GitCommit)
                     .ConfigureAwait(false);
             }
 
@@ -218,7 +222,7 @@ namespace Octopus.Cli.Commands.Releases
             if (await ServerSupportsChannels().ConfigureAwait(false))
             {
                 commandOutputProvider.Debug("Automatically selecting the best channel for this release...");
-                return await AutoSelectBestReleasePlanOrThrow(project).ConfigureAwait(false);
+                return await AutoSelectBestReleasePlanOrThrow().ConfigureAwait(false);
             }
 
             // Compatibility: this has to cater for Octopus before Channels existed
@@ -227,7 +231,8 @@ namespace Octopus.Cli.Commands.Releases
                     project,
                     null,
                     VersionPreReleaseTag,
-                    GitReference)
+                    GitReference,
+                    GitCommit)
                 .ConfigureAwait(false);
         }
 
@@ -236,21 +241,32 @@ namespace Octopus.Cli.Commands.Releases
             return Repository.HasLink("Channels");
         }
 
-        async Task<ReleasePlan> AutoSelectBestReleasePlanOrThrow(ProjectResource project)
+        async Task<ResourceCollection<ChannelResource>> GetChannel()
+        {
+            if (!project.IsVersionControlled)
+            {
+                return await Repository.Projects.GetChannels(project).ConfigureAwait(false);    
+            }
+
+            return await Repository.Projects.Beta().GetChannels(project, GitCommit ?? GitReference).ConfigureAwait(false);
+        }
+
+        async Task<ReleasePlan> AutoSelectBestReleasePlanOrThrow()
         {
             // Build a release plan for each channel to determine which channel is the best match for the provided options
-            var channels = await Repository.Projects.GetChannels(project).ConfigureAwait(false);
+            var channels = await GetChannel().ConfigureAwait(false);
             var candidateChannels = await channels.GetAllPages(Repository).ConfigureAwait(false);
             var releasePlans = new List<ReleasePlan>();
             foreach (var channel in candidateChannels)
             {
                 commandOutputProvider.Information("Building a release plan for Channel '{Channel:l}'...", channel.Name);
 
-                var plan = await releasePlanBuilder.Build(Repository,
+                plan = await releasePlanBuilder.Build(Repository,
                         project,
                         channel,
                         VersionPreReleaseTag,
-                        GitReference)
+                        GitReference,
+                        GitCommit)
                     .ConfigureAwait(false);
                 releasePlans.Add(plan);
                 if (plan.ChannelHasAnyEnabledSteps() == false)
@@ -288,6 +304,35 @@ namespace Octopus.Cli.Commands.Releases
                 $"{releasePlans.Except(viablePlans).Select(p => p.FormatAsTable()).NewlineSeperate()}");
         }
 
+        /// <summary>
+        /// if no release notes were provided on the command line, but the project has a template, then use the template
+        /// </summary>
+        async Task ReleaseNotesFallBackToDeploymentSettings()
+        {
+            if (!string.IsNullOrWhiteSpace(ReleaseNotes))
+                return;
+
+            // Continue using deprecated property on DeploymentSettings that exposes project for older server backwards compatibility
+#pragma warning disable 618
+            var projectReleaseNotes = project.ReleaseNotesTemplate;
+#pragma warning restore 618
+
+            if (project.IsVersionControlled)
+            {
+                var deploymentSettings = await Repository.DeploymentSettings.Beta().Get(project, GitCommit ?? GitReference)
+                    .ConfigureAwait(false);
+                projectReleaseNotes = deploymentSettings.ReleaseNotesTemplate;
+            }
+            else if ((await Repository.LoadRootDocument().ConfigureAwait(false)).HasProjectDeploymentSettingsSeparation())
+            {
+                var deploymentSettings = await Repository.DeploymentSettings.Get(project).ConfigureAwait(false);
+                projectReleaseNotes = deploymentSettings.ReleaseNotesTemplate;
+            }
+
+            if (!string.IsNullOrWhiteSpace(projectReleaseNotes))
+                ReleaseNotes = projectReleaseNotes;
+        }
+
         void ReadReleaseNotesFromFile(string value)
         {
             try
@@ -322,6 +367,22 @@ namespace Octopus.Cli.Commands.Releases
                     VersionRule = x.ChannelVersionRuleTestResult?.ToSummaryString()
                 })
             });
+        }
+        
+        void ValidateProjectPersistenceRequirements()
+        {
+            var wasGitRefProvided = !string.IsNullOrEmpty(GitReference);
+            if (project.IsVersionControlled && !wasGitRefProvided)
+            {
+                throw new CommandException($"Since the provided project is a version controlled project "
+                    + $"you must provide the gitRef used for this release via the --gitRef argument.");    
+            }
+
+            if (!project.IsVersionControlled && wasGitRefProvided)
+            {
+                throw new CommandException($"Since the provided project is not a version controlled project,"
+                    + $" the --commit and --gitRef arguments are not supported for this command.");
+            }
         }
     }
 }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -43,7 +43,7 @@ namespace Octopus.Cli.Commands.Releases
             var options = Options.For("Release creation");
             options.Add<string>("project=", "Name or ID of the project.", v => ProjectNameOrId = v);
             options.Add<string>("defaultPackageVersion=|packageVersion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
-            options.Add<string>("commit=", "[Optional, Experimental] Git commit to use when creating the release. Use in conjunction with the --gitRef parameter.", v => GitCommit = v);
+            options.Add<string>("gitCommit=", "[Optional, Experimental] Git commit to use when creating the release. Use in conjunction with the --gitRef parameter.", v => GitCommit = v);
             options.Add<string>("ref=|gitRef=", "[Optional, Experimental] Git reference to use when creating the release.", v => GitReference = v);
             options.Add<string>("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add<string>("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);
@@ -381,7 +381,7 @@ namespace Octopus.Cli.Commands.Releases
             if (!project.IsVersionControlled && wasGitRefProvided)
             {
                 throw new CommandException($"Since the provided project is not a version controlled project,"
-                    + $" the --commit and --gitRef arguments are not supported for this command.");
+                    + $" the --gitCommit and --gitRef arguments are not supported for this command.");
             }
         }
     }

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -43,7 +43,7 @@ namespace Octopus.Cli.Commands.Releases
             var options = Options.For("Release creation");
             options.Add<string>("project=", "Name or ID of the project.", v => ProjectNameOrId = v);
             options.Add<string>("defaultPackageVersion=|packageVersion=", "Default version number of all packages to use for this release. Override per-package using --package.", versionResolver.Default);
-            options.Add<string>("gitCommit=", "[Optional, Experimental] Git commit to use when creating the release. Use in conjunction with the --gitRef parameter.", v => GitCommit = v);
+            options.Add<string>("gitCommit=", "[Optional, Experimental] Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit.", v => GitCommit = v);
             options.Add<string>("ref=|gitRef=", "[Optional, Experimental] Git reference to use when creating the release.", v => GitReference = v);
             options.Add<string>("version=|releaseNumber=", "[Optional] Release number to use for the new release.", v => VersionNumber = v);
             options.Add<string>("channel=", "[Optional] Name or ID of the channel to use for the new release. Omit this argument to automatically select the best channel.", v => ChannelNameOrId = v);

--- a/source/Octopus.Cli/Commands/Releases/IReleasePlanBuilder.cs
+++ b/source/Octopus.Cli/Commands/Releases/IReleasePlanBuilder.cs
@@ -11,6 +11,7 @@ namespace Octopus.Cli.Commands.Releases
             ProjectResource project,
             ChannelResource channel,
             string versionPreReleaseTag,
-            string gitReference);
+            string gitReference,
+            string gitCommit);
     }
 }

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="8.8.8" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3424" />
     <PackageReference Include="Octopus.CommandLine" Version="0.0.112" />
     <PackageReference Include="Octopus.Client" Version="11.3.3415" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
     <PackageReference Include="Octopus.Client" Version="8.8.8" />
     <PackageReference Include="Octopus.CommandLine" Version="0.0.112" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3415" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />

--- a/source/Octopus.Cli/Util/FeatureDetectionExtensions.cs
+++ b/source/Octopus.Cli/Util/FeatureDetectionExtensions.cs
@@ -30,8 +30,17 @@ namespace Octopus.Cli.Util
         public static bool UsePostForChannelVersionRuleTest(this RootResource source)
         {
             // Assume octo 3.4 should use the OctopusServer 3.4 POST, otherwise if we're certain this is an older Octopus Server use the GET method
-            SemanticVersion octopusServerVersion;
-            return source == null || !SemanticVersion.TryParse(source.Version, out octopusServerVersion) || octopusServerVersion >= new SemanticVersion("3.4");
+            return source == null || 
+                !SemanticVersion.TryParse(source.Version, out var octopusServerVersion) || 
+                octopusServerVersion >= new SemanticVersion("3.4");
+        }
+        
+        public static bool HasProjectDeploymentSettingsSeparation(this RootResource source)
+        {
+            // The separation of Projects from DeploymentSettings was exposed from 2021.2 onwards
+            return source == null || 
+                !SemanticVersion.TryParse(source.Version, out var octopusServerVersion) ||
+                octopusServerVersion >= new SemanticVersion("2021.2");
         }
     }
 }


### PR DESCRIPTION
Added support for `--gitCommit` parameter 

**Release with `--gitCommit` (note `--gitRef` is still required)**
> Octopus Deploy Command Line Tool, version 1.0.0
> 
> Detected automation environment: "NoneOrUnknown"
> Space name unspecified, process will run in the default space context
> Handshaking with Octopus Server: http://localhost:8065
> Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
> Authenticated as: admin
> Found environments:
> This Octopus Server supports channels
> Found project: Simple Project (Projects-1)
> Automatically selecting the best channel for this release...
> Building a release plan for Channel 'Default'...
> Finding deployment process at git commit c5cb0388ce999b64308bb2abd0db705832ff2afb...
> Finding release template at git commit c5cb0388ce999b64308bb2abd0db705832ff2afb...
> Selected the release plan for Channel 'Default' - it is a perfect match
> Using version number from release template: 0.0.5
> Release plan for Simple Project 0.0.5
> Channel: 'Default' (this is the default channel)
> 
> Creating release...
> Release 0.0.5 created successfully!
> Release created from commit c5cb0388ce999b64308bb2abd0db705832ff2afb of git reference master.


**Release with just `--gitRef`**
> Octopus Deploy Command Line Tool, version 1.0.0
> 
> Detected automation environment: "NoneOrUnknown"
> Space name unspecified, process will run in the default space context
> Handshaking with Octopus Server: http://localhost:8065
> Handshake successful. Octopus version: 0.0.0-local; API version: 3.0.0
> Authenticated as: admin
> Found environments:
> This Octopus Server supports channels
> Found project: Simple Project (Projects-1)
> Automatically selecting the best channel for this release...
> Building a release plan for Channel 'Default'...
> Finding deployment process at git reference master...
> Finding release template at git reference master...
> Selected the release plan for Channel 'Default' - it is a perfect match
> Using version number from release template: 0.0.6
> Release plan for Simple Project 0.0.6
> Channel: 'Default' (this is the default channel)
> 
> Creating release...
> Release 0.0.6 created successfully!
> Release created from commit 23b923bfa433233798697e2a420c76f962f2d030 of git reference master.

### Note: This update also requires a corresponding change from OctopusClients which, once merged, will allow accessing resources based on their commits rather than just branch. This is required for the ReleasePlanBuilder to determine package requirements. (Hence some failing tests)

