### PR TITLE
If gitRef is not provided, fall back to using the default branch

### DIFF
--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -382,9 +382,11 @@ namespace Octopus.Cli.Commands.Releases
         void ValidateProjectPersistenceRequirements()
         {
             var wasGitRefProvided = !string.IsNullOrEmpty(GitReference);
-            if (project.IsVersionControlled && !wasGitRefProvided)
-                throw new CommandException("Since the provided project is a version controlled project "
-                    + "you must provide the gitRef used for this release via the --gitRef argument.");
+            if (project.PersistenceSettings is VersionControlSettingsResource vcsResource && !wasGitRefProvided)
+            {
+                GitReference = vcsResource.DefaultBranch;
+                commandOutputProvider.Information("No gitRef parameter provided. Using Project Default Branch: {DefaultBranch:l}", vcsResource.DefaultBranch);
+            }
 
             if (!project.IsVersionControlled && wasGitRefProvided)
                 throw new CommandException("Since the provided project is not a version controlled project,"


### PR DESCRIPTION
This change is to make the conversion from DB to VCS smoother for customers by avoiding the requirement to rewrite their build pipelines. The API itself still requires the gitref as provided by the portal and this change simply boils down to the cli tool setting the default.
Probably not what we would have built if we were creating this from scratch, but it simplifies the migration process and I could see us enforcing this a lot more once the initial adoption.