### PR TITLE
Drop netcore2.0 as it's EOL

### DIFF
--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine
+FROM mcr.microsoft.com/dotnet/core/runtime:5.0-alpine
 
 # Alpine base image does not have ICU libraries available
 # https://github.com/dotnet/corefx/blob/master/Documentation/architecture/globalization-invariant-mode.md

--- a/Dockerfiles/alpine/Dockerfile
+++ b/Dockerfiles/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:5.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine
 
 # Alpine base image does not have ICU libraries available
 # https://github.com/dotnet/corefx/blob/master/Documentation/architecture/globalization-invariant-mode.md

--- a/Dockerfiles/nanoserver/Dockerfile
+++ b/Dockerfiles/nanoserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/runtime:3.1-nanoserver-20H2
+FROM mcr.microsoft.com/dotnet/runtime:5.0-nanoserver-20H2
 ARG OCTO_TOOLS_VERSION=4.31.1
 
 LABEL maintainer="devops@octopus.com"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -146,7 +146,7 @@ class Build : NukeBuild
                 DotNetPublish(_ => _
                     .SetProject(Solution.Octo)
                     .SetConfiguration(Configuration)
-                    .SetFramework("netcoreapp3.1")
+                    .SetFramework("net5.0")
                     .SetRuntime(rid)
                     .EnableSelfContained()
                     .EnablePublishSingleFile()

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,19 +135,6 @@ class Build : NukeBuild
                 .SetOutput(OctoPublishDirectory / "netfx")
                 .SetVersion(OctoVersionInfo.FullSemVer));
 
-            var portablePublishDir = OctoPublishDirectory / "portable";
-            DotNetPublish(_ => _
-                .SetProject(Solution.Octo)
-                .SetFramework("netcoreapp2.0") /* For compatibility until we gently phase it out. We encourage upgrading to self-contained executable. */
-                .SetConfiguration(Configuration)
-                .SetOutput(portablePublishDir)
-                .SetVersion(OctoVersionInfo.FullSemVer));
-
-            SignBinaries(portablePublishDir);
-
-            CopyFileToDirectory(AssetDirectory / "octo", portablePublishDir, FileExistsPolicy.Overwrite);
-            CopyFileToDirectory(AssetDirectory / "octo.cmd", portablePublishDir, FileExistsPolicy.Overwrite);
-
             var doc = new XmlDocument();
             doc.Load(Solution.Octo.Path);
             var selectSingleNode = doc.SelectSingleNode("Project/PropertyGroup/RuntimeIdentifiers");

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -135,6 +135,18 @@ class Build : NukeBuild
                 .SetOutput(OctoPublishDirectory / "netfx")
                 .SetVersion(OctoVersionInfo.FullSemVer));
 
+            //used for docker containers
+            var portablePublishDir = OctoPublishDirectory / "portable";
+            DotNetPublish(_ => _
+                .SetProject(Solution.Octo)
+                .SetFramework("net5.0")
+                .SetConfiguration(Configuration)
+                .SetOutput(portablePublishDir)
+                .SetVersion(OctoVersionInfo.FullSemVer));
+            SignBinaries(portablePublishDir);
+            CopyFileToDirectory(AssetDirectory / "octo", portablePublishDir, FileExistsPolicy.Overwrite);
+            CopyFileToDirectory(AssetDirectory / "octo.cmd", portablePublishDir, FileExistsPolicy.Overwrite);
+
             var doc = new XmlDocument();
             doc.Load(Solution.Octo.Path);
             var selectSingleNode = doc.SelectSingleNode("Project/PropertyGroup/RuntimeIdentifiers");

--- a/source/Octo.Tests/Commands/VersionTestFixture.cs
+++ b/source/Octo.Tests/Commands/VersionTestFixture.cs
@@ -46,11 +46,18 @@ namespace Octo.Tests.Commands
 
         static string AssemblyPath()
         {
-            var codeBase = Assembly.GetExecutingAssembly().CodeBase;
-            var uri = new UriBuilder(codeBase);
-            var root = Uri.UnescapeDataString(uri.Path);
-            root = root.Replace('/', Path.DirectorySeparatorChar);
-            return root;
+            #if NETFRAMEWORK
+                //SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are
+                //only included for .NET Framework compatibility. Use Assembly.Location instead.'
+
+                var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+                var uri = new UriBuilder(codeBase);
+                var root = Uri.UnescapeDataString(uri.Path);
+                root = root.Replace('/', Path.DirectorySeparatorChar);
+                return root;
+           #else
+                return Assembly.GetExecutingAssembly().Location;
+            #endif
         }
 
         string GetVersionFromFile(string versionFilePath)

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;net5.0</TargetFrameworks>
+    <TargetFramework Condition="$([MSBuild]::IsOSUnixLike())">net5.0</TargetFramework>
     <AssemblyName>Octo.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <DefineConstants>$(DefineConstants);HAS_APP_CONTEXT</DefineConstants>
   </PropertyGroup>
 
@@ -48,7 +48,7 @@
   </ItemGroup>
 
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0" />

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Cli\Octopus.Cli.csproj" />
   </ItemGroup>

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;net5.0</TargetFrameworks>
+    <TargetFramework Condition="$([MSBuild]::IsOSUnixLike())">net5.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>portable</DebugType>
     <AssemblyName>octo</AssemblyName>

--- a/source/Octo/Octo.csproj
+++ b/source/Octo/Octo.csproj
@@ -17,7 +17,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0</TargetFrameworks>
+    <TargetFramework Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0</TargetFramework>
     <Authors>Octopus Deploy</Authors>
     <Copyright>Octopus Deploy Pty Ltd</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
+++ b/source/Octopus.DotNet.Cli/Octopus.DotNet.Cli.csproj
@@ -6,7 +6,7 @@
     We include all possible targets here so that no matter what framework version
     the user has installed, there is an appropriate build in the tools package
     -->
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <PackAsTool>True</PackAsTool>
     <AssemblyName>dotnet-octo</AssemblyName>
     <PackageId>Octopus.DotNet.Cli</PackageId>


### PR DESCRIPTION
According to the [dotnet core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core):

- .Net Core 2.0 went EOL on October 1, 2018
- .Net Core 2.1 went EOL on  August 21, 2021
- .Net Core 2.2 went EOL on  December 23, 2019
- .Net Core 3.0 went EOL on  March 3, 2020

We will also need to modify the OctopusCLI [downloads page](https://octopus.com/downloads/octopuscli#netcore) (specifically [OctopusCLI.cshtml](https://github.com/OctopusDeploy/Octofront/blob/master/source/Octofront.Web.Public/Views/Downloads/OctopusCli/OctopusCli.cshtml) and [DownloadManager.cs](https://github.com/OctopusDeploy/Octofront/blob/master/source/Octofront.Core/Downloads/DownloadManager.cs#L136-L157)) to remove the `.NET Core 2.0` tab. 

Maybe we should replace it with guidance around using the dotnet tool?

