### PR TITLE
Update client and remove `.Beta()` usages

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -28,7 +28,6 @@ namespace Octo.Tests.Commands
         IChannelVersionRuleTester versionRuleTester;
         IOctopusAsyncRepository repository;
         IDeploymentProcessRepository deploymentProcessRepository;
-        IDeploymentProcessBetaRepository deploymentProcessRepositoryBeta;
         IReleaseRepository releaseRepository;
         IFeedRepository feedRepository;
         ICommandOutputProvider commandOutputProvider;
@@ -96,10 +95,6 @@ namespace Octo.Tests.Commands
                 .Test(Arg.Any<IOctopusAsyncRepository>(), Arg.Any<ChannelVersionRuleResource>(), Arg.Any<string>(), Arg.Any<string>())
                 .Returns(Task.FromResult(channelVersionRuleTestResult));
 
-            deploymentProcessRepositoryBeta = Substitute.For<IDeploymentProcessBetaRepository>();
-            deploymentProcessRepositoryBeta.Get(projectResource, Arg.Any<string>())
-                .Returns(Task.FromResult(deploymentProcessResource));
-
             var feeds = new List<FeedResource>
             {
                 feedResource
@@ -111,7 +106,6 @@ namespace Octo.Tests.Commands
 
             repository = Substitute.For<IOctopusAsyncRepository>();
             repository.DeploymentProcesses.Returns(deploymentProcessRepository);
-            repository.DeploymentProcesses.Beta().Returns(deploymentProcessRepositoryBeta);
             repository.Releases.Returns(releaseRepository);
             repository.Feeds.Returns(feedRepository);
             repository.Client

--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -87,6 +87,8 @@ namespace Octo.Tests.Commands
             deploymentProcessRepository = Substitute.For<IDeploymentProcessRepository>();
             deploymentProcessRepository.Get(projectResource.DeploymentProcessId)
                 .Returns(Task.FromResult(deploymentProcessResource));
+            deploymentProcessRepository.Get(projectResource, Arg.Any<string>())
+                .Returns(Task.FromResult(deploymentProcessResource));
             deploymentProcessRepository
                 .GetTemplate(Arg.Is(deploymentProcessResource),
                     Arg.Is(channelResource))

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -30,10 +30,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
-    <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
+    <PackageReference Include="Octopus.Server.Client" Version="11.4.3551" />
     <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.0.364" />
-    <PackageReference Include="Octopus.Client" Version="11.3.3550-robe-no-beta" />
-    <PackageReference Include="Octopus.Client" Version="11.4.3551" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
     <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
     <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.0.364" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3550-robe-no-beta" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octo.Tests/Octo.Tests.csproj
+++ b/source/Octo.Tests/Octo.Tests.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
     <PackageReference Include="Octopus.Server.MessageContracts.Base" Version="3.0.364" />
     <PackageReference Include="Octopus.Client" Version="11.3.3550-robe-no-beta" />
+    <PackageReference Include="Octopus.Client" Version="11.4.3551" />
     <PackageReference Include="Serilog.Sinks.TextWriter" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />

--- a/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
+++ b/source/Octopus.Cli/Commands/Releases/CreateReleaseCommand.cs
@@ -248,18 +248,10 @@ namespace Octopus.Cli.Commands.Releases
             return Repository.HasLink("Channels");
         }
 
-        async Task<ResourceCollection<ChannelResource>> GetChannel()
-        {
-            if (!project.IsVersionControlled)
-                return await Repository.Projects.GetChannels(project).ConfigureAwait(false);
-
-            return await Repository.Projects.Beta().GetChannels(project, GitCommit ?? GitReference).ConfigureAwait(false);
-        }
-
         async Task<ReleasePlan> AutoSelectBestReleasePlanOrThrow()
         {
             // Build a release plan for each channel to determine which channel is the best match for the provided options
-            var channels = await GetChannel().ConfigureAwait(false);
+            var channels = await Repository.Projects.GetChannels(project).ConfigureAwait(false);
             var candidateChannels = await channels.GetAllPages(Repository).ConfigureAwait(false);
             var releasePlans = new List<ReleasePlan>();
             foreach (var channel in candidateChannels)
@@ -324,7 +316,7 @@ namespace Octopus.Cli.Commands.Releases
 
             if (project.IsVersionControlled)
             {
-                var deploymentSettings = await Repository.DeploymentSettings.Beta()
+                var deploymentSettings = await Repository.DeploymentSettings
                     .Get(project, GitCommit ?? GitReference)
                     .ConfigureAwait(false);
                 projectReleaseNotes = deploymentSettings.ReleaseNotesTemplate;

--- a/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
@@ -66,7 +66,7 @@ namespace Octopus.Cli.Commands.Releases
                 throw new CommandException(GitReferenceSuppliedForDatabaseProjectErrorMessage(gitObjectName));
 
             commandOutputProvider.Debug($"Finding deployment process at git {gitObjectName}...");
-            var deploymentProcess = await repository.DeploymentProcesses.Beta().Get(project, gitObject);
+            var deploymentProcess = await repository.DeploymentProcesses.Get(project, gitObject);
             if (deploymentProcess == null)
                 throw new CouldNotFindException($"a deployment process for project {project.Name} and git {gitObjectName}");
 

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="11.3.3550-robe-no-beta" />
+    <PackageReference Include="Octopus.Client" Version="11.4.3551" />
     <PackageReference Include="Octopus.CommandLine" Version="0.0.112" />
     <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -35,9 +35,8 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
-    <PackageReference Include="Octopus.Client" Version="11.4.3551" />
     <PackageReference Include="Octopus.CommandLine" Version="0.0.112" />
-    <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
+    <PackageReference Include="Octopus.Server.Client" Version="11.4.3551" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />
     <PackageReference Include="Octostache" Version="2.3.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="2.0.0" />

--- a/source/Octopus.Cli/Octopus.Cli.csproj
+++ b/source/Octopus.Cli/Octopus.Cli.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="NuGet.Packaging.Core" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="3.6.0-octopus-58692" />
     <PackageReference Include="NuGet.Versioning" Version="3.6.0-octopus-58692" />
+    <PackageReference Include="Octopus.Client" Version="11.3.3550-robe-no-beta" />
     <PackageReference Include="Octopus.CommandLine" Version="0.0.112" />
     <PackageReference Include="Octopus.Server.Client" Version="11.3.3543" />
     <PackageReference Include="Octopus.Versioning" Version="4.3.5" />


### PR DESCRIPTION
Updating Client due to https://github.com/OctopusDeploy/OctopusClients/pull/627
This isn't a critical roll forward since the old routes etc are all still valid, this just cleans up the embedded client