### PR TITLE
Change release process to use slipway

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -2,7 +2,6 @@ step "Upload OctopusTools to S3 public with hashes" {
 
     action {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-864"
             Octopus.Action.Template.Version = "4"
             PackageToUpload = "{\"PackageId\":\"OctopusTools.Zips\",\"FeedId\":\"Octopus Server (built-in)\"}"
@@ -30,7 +29,6 @@ step "Push Octopus.Cli to feedz.io" {
         action_type = "Octopus.Script"
         environments = ["Components - Internal"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
@@ -73,7 +71,6 @@ step "Push Octopus.Cli to NuGet Gallery" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
@@ -114,7 +111,6 @@ step "Push Octopus.DotNet.Cli to feedz.io" {
         action_type = "Octopus.Script"
         environments = ["Components - Internal"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
@@ -155,7 +151,6 @@ step "Push Octopus.DotNet.Cli to NuGet Gallery" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
@@ -196,7 +191,6 @@ step "Push OctopusTools to feedz.io" {
         action_type = "Octopus.Script"
         environments = ["Components - Internal"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
@@ -237,7 +231,6 @@ step "Push OctopusTools to NuGet Gallery" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
                 $nugetExe = Join-Path -Path $nugetPackagePath -ChildPath "Tools\nuget.exe"
@@ -290,7 +283,6 @@ step "Push OctopusTools to Chocolatey" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
                 $nugetExe = Join-Path -Path $nugetPackagePath -ChildPath "Tools\nuget.exe"
@@ -343,7 +335,6 @@ step "Publish Homebrew" {
         channels = ["Default"]
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-882"
             Octopus.Action.Template.Version = "18"
             PackageToUpload = "{\"PackageId\":\"OctopusTools.Zips\",\"FeedId\":\"Octopus Server (built-in)\"}"
@@ -374,7 +365,6 @@ step "Publish to APT repo" {
     action {
         action_type = "Octopus.Script"
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 cd OctopusTools.Packages.linux-x64 || exit
                 
@@ -411,7 +401,6 @@ step "Publish to RPM repo" {
     action {
         action_type = "Octopus.Script"
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 cd OctopusTools.Packages.linux-x64 || exit
                 
@@ -454,7 +443,6 @@ step "Move Docker Images To Prod" {
             mditp_ImageTag = "#{Octopus.Release.Number}"
             mditp_PreReleaseImage = "octopusdeploy/octo-prerelease"
             mditp_ReleaseImage = "octopusdeploy/octo"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-883"
             Octopus.Action.Template.Version = "2"
         }
@@ -468,7 +456,6 @@ step "Upload OctopusTools Manifest to S3" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 Import-Module AWSPowerShell.NetCore
                 $version = $OctopusParameters['Octopus.Action.Package[OctopusTools.Zips].PackageVersion']
@@ -585,7 +572,6 @@ step "Create release in Octofront" {
         action_type = "Octopus.Script"
         environments = ["Components - External"]
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 $octofrontToken = $OctopusParameters["OctofrontToken"]
                 $baseUrl = $OctopusParameters["OctofrontUrl"]
@@ -654,7 +640,6 @@ step "Invalidate CloudFront Cache" {
             icfc_awsaccount = "OctopusToolsAwsAccount"
             icfc_distributionid = "E1ZC8NX4KJYKDL"
             icfc_invalidationpaths = "/octopus-tools/latest.json"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-962"
             Octopus.Action.Template.Version = "1"
         }
@@ -670,7 +655,6 @@ step "Invalidate CloudFlare cache of the OctopusTools Manifest" {
             icfc_hostname = "download.octopusdeploy.com"
             icfc_token = "#{CloudFlareKey}"
             icfc_zone = "ec51e468948315337a746fab4e064456"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-963"
             Octopus.Action.Template.Version = "6"
         }

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -565,7 +565,7 @@ step "Upload OctopusTools Manifest to S3" {
     }
 }
 
-step "Create release in Octofront" {
+step "Create release in Slipway" {
     start_trigger = "StartWithPrevious"
 
     action {
@@ -573,16 +573,16 @@ step "Create release in Octofront" {
         environments = ["Components - External"]
         properties = {
             Octopus.Action.Script.ScriptBody = <<-EOT
-                $octofrontToken = $OctopusParameters["OctofrontToken"]
-                $baseUrl = $OctopusParameters["OctofrontUrl"]
+                $slipwayToken = $OctopusParameters["SlipwayToken"]
+                $baseUrl = $OctopusParameters["SlipwayUrl"]
                 $version = $OctopusParameters["Octopus.Release.Number"]
                 $releaseNotes = $OctopusParameters["Octopus.Release.Notes"]
                 
-                $headers = @{ "Authorization" = "Bearer $octofrontToken" }
+                $headers = @{ "Authorization" = "Bearer $slipwayToken" }
                 
                 function ReleaseToWeb([string]$productName, $versionToRelease, [string]$releaseNotes)
                 {
-                    write-host "Publishing '$productName' '$versionToRelease' to Octofront at $baseUrl"
+                    write-host "Publishing '$productName' '$versionToRelease' to Slipway at $baseUrl"
                 
                     $isPreRelease = $versionToRelease -like "*-*"
                     $release = @{
@@ -606,10 +606,10 @@ step "Create release in Octofront" {
                                           -Headers $headers
                     }
                     catch {
-                        throw "An error occurred while publishing '$productName' release '$versionToRelease' to Octofront: $_"
+                        throw "An error occurred while publishing '$productName' release '$versionToRelease' to Slipway: $_"
                     }
                 
-                    $releaseUrl = "https://octopusdeploy.com/downloads/$($release.VersionNumber)"
+                    $releaseUrl = "https://octopusdeploy.com/downloads/$productName/$($release.VersionNumber)"
                     write-highlight "'$productName' '$versionToRelease' was published to '$releaseUrl'"
                 }
                 

--- a/.octopus/schema-version.ocl
+++ b/.octopus/schema-version.ocl
@@ -1,1 +1,0 @@
-version = 2

--- a/.octopus/schema_version.ocl
+++ b/.octopus/schema_version.ocl
@@ -1,0 +1,1 @@
+version = 3


### PR DESCRIPTION
Slipway is the new place where we manage our releases - pulled out from octofront.

Looks like a migration happened as well - there's a bunch of change in there that's not mine...