### PR TITLE
Fixed package reference name comparison in ReleasePlan

### DIFF
--- a/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlan.cs
@@ -240,7 +240,7 @@ namespace Octopus.Cli.Commands.Releases
         public string GetActionVersionNumber(string packageStepName, string packageReferenceName)
         {
             var step = packageSteps.SingleOrDefault(s => s.ActionName.Equals(packageStepName, StringComparison.OrdinalIgnoreCase) &&
-                (string.IsNullOrWhiteSpace(s.PackageReferenceName) || s.PackageReferenceName.Equals(packageReferenceName ?? string.Empty, StringComparison.OrdinalIgnoreCase)));
+                ((string.IsNullOrWhiteSpace(s.PackageReferenceName) && string.IsNullOrWhiteSpace(packageReferenceName)) || s.PackageReferenceName.Equals(packageReferenceName ?? string.Empty, StringComparison.OrdinalIgnoreCase)));
             if (step == null)
                 throw new CommandException("The step '" + packageStepName + "' is configured to provide the package version number but doesn't exist in the release plan.");
             if (string.IsNullOrWhiteSpace(step.Version))


### PR DESCRIPTION
Adjust the package reference name check to fix a missing edge case. The comparison should have been checked whether the passed value and the step reference value were both null/empty OR equal using a case-insensitive comparison.

Fixes #166