### PR TITLE
Following advice from https://docs.microsoft.com/en-us/dotnet/api/System.Net.ServicePointManager.SecurityProtocol?view=net-6.0#remarks

### DIFF
--- a/source/Octopus.Cli/CliProgram.cs
+++ b/source/Octopus.Cli/CliProgram.cs
@@ -23,10 +23,6 @@ namespace Octopus.Cli
     {
         public int Execute(string[] args)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
-                | SecurityProtocolType.Tls11
-                | SecurityProtocolType.Tls12;
-
             ConfigureLogger();
             return Run(args);
         }


### PR DESCRIPTION
In summary, we let the OS mandate what TLS version is used, this given control to the system administrators.
Fixes https://github.com/OctopusDeploy/OctopusCLI/issues/170