### PR TITLE
Always use ID when fetching feeds

### DIFF
--- a/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
+++ b/source/Octo.Tests/Commands/ReleasePlanBuilderTests.cs
@@ -338,7 +338,7 @@ namespace Octo.Tests.Commands
             // arrange
             gitReference = "main";
             projectResource.IsVersionControlled = true;
-            releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage(ResourceBuilderHelpers.KeyedBy.Name).IsResolvable());
+            releaseTemplateResource.Packages.Add(GetReleaseTemplatePackage().WithPackage().IsResolvable());
             packages.Add(new PackageResource { Version = "1.0.0" });
 
             // act
@@ -384,12 +384,6 @@ namespace Octo.Tests.Commands
 
     public static class ResourceBuilderHelpers
     {
-        public enum KeyedBy
-        {
-            Id,
-            Name
-        }
-
         public static DeploymentActionResource WithPackage(this DeploymentActionResource action)
         {
             action.Properties["Octopus.Action.Package.PackageId"] = TestHelpers.GetId("package");
@@ -408,10 +402,10 @@ namespace Octo.Tests.Commands
             return action;
         }
 
-        public static ReleaseTemplatePackage WithPackage(this ReleaseTemplatePackage releaseTemplatePackage, KeyedBy keyedBy = KeyedBy.Id)
+        public static ReleaseTemplatePackage WithPackage(this ReleaseTemplatePackage releaseTemplatePackage)
         {
             releaseTemplatePackage.PackageId = TestHelpers.GetId("package");
-            var feedKey = keyedBy == KeyedBy.Id ? ReleasePlanBuilderTests.BuiltInFeedId : "Built in feed";
+            var feedKey = ReleasePlanBuilderTests.BuiltInFeedId;
             releaseTemplatePackage.FeedId = feedKey;
             return releaseTemplatePackage;
         }

--- a/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
+++ b/source/Octopus.Cli/Commands/Releases/ReleasePlanBuilder.cs
@@ -198,9 +198,7 @@ namespace Octopus.Cli.Commands.Releases
         {
             // PackageFeedId can be an id or a name
             var allRelevantFeedIdOrName = steps.Select(step => step.PackageFeedId).ToArray();
-            var allRelevantFeeds = project.IsVersionControlled
-                ? (await repository.Feeds.FindByNames(allRelevantFeedIdOrName).ConfigureAwait(false)).ToDictionary(feed => feed.Name)
-                : (await repository.Feeds.Get(allRelevantFeedIdOrName).ConfigureAwait(false)).ToDictionary(feed => feed.Id);
+            var allRelevantFeeds = (await repository.Feeds.Get(allRelevantFeedIdOrName).ConfigureAwait(false)).ToDictionary(feed => feed.Id);
 
             return allRelevantFeeds;
         }


### PR DESCRIPTION
Fixes a bug where creating a release for config as code projects would fail when fetching packages, since IDs are now used again in the API instead of names.

Closes https://github.com/OctopusDeploy/Issues/issues/7660