### PR TITLE
Updated the build pipeline to push release notes through to the Octopus website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and unit test code
     runs-on: windows-latest
     # conditionally skip build on PR merge of release-please, because the release creation is going to trigger the real build
-    if: ${{ github.ref_name != default-branch || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
+    if: ${{ github.ref_name != github.event.repository.default_branch || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
     outputs:
       version: ${{ steps.nuke-build.outputs.version }}
     steps:
@@ -264,5 +264,5 @@ jobs:
         package_version: ${{ needs.build.outputs.version }}
         packages: '*:NuGet.CommandLine:4.4.1'
         release_notes_file: ${{ (github.event_name == 'release' && steps.fetch-release-notes.outputs.release-note-file) || ''}}
-        git_ref: ${{ (github.ref_type == 'tag' && default-branch ) || (github.head_ref || github.ref) }}
+        git_ref: ${{ (github.ref_type == 'tag' && github.event.repository.default_branch ) || (github.head_ref || github.ref) }}
         git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: '**'
   release:
-    types: [published]
+    types: [created]
   schedule:
     # Daily 5am australian/brisbane time (7pm UTC)
     - cron: '0 19 * * *'
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build and unit test code
     runs-on: windows-latest
+    # conditionally skip build on PR merge of release-please, because the release creation is going to trigger the real build
+    if: ${{ github.ref_name != $default-branch || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
     outputs:
       version: ${{ steps.nuke-build.outputs.version }}
     steps:
@@ -245,6 +247,15 @@ jobs:
           artifacts/OctopusTools.Packages.linux-x64.${{ needs.build.outputs.version }}.zip
           artifacts/OctopusTools.Zips.${{ needs.build.outputs.version }}.zip
 
+    - name: Fetch Release Notes
+      id: fetch-release-notes
+      if: github.event_name == 'release'
+      run: |
+        echo "::debug::${{github.event_name}}"
+        OUTPUT_FILE="release_notes.txt"
+        jq --raw-output '.release.body' ${{ github.event_path }} | sed 's#\r#  #g' > $OUTPUT_FILE
+        echo "::set-output name=release-note-file::$OUTPUT_FILE"
+
     - name: Create a release in Octopus Deploy 🐙
       uses: OctopusDeploy/create-release-action@v1.1.3
       with:
@@ -252,5 +263,6 @@ jobs:
         project: 'Octopus CLI'
         package_version: ${{ needs.build.outputs.version }}
         packages: '*:NuGet.CommandLine:4.4.1'
-        git_ref: ${{ (github.ref_type == 'tag' && 'main' ) || (github.head_ref || github.ref) }}
+        release_notes_file: ${{ (github.event_name == 'release' && steps.fetch-release-notes.outputs.release-note-file) || ''}}
+        git_ref: ${{ (github.ref_type == 'tag' && $default-branch ) || (github.head_ref || github.ref) }}
         git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and unit test code
     runs-on: windows-latest
     # conditionally skip build on PR merge of release-please, because the release creation is going to trigger the real build
-    if: ${{ github.ref_name != $default-branch || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
+    if: ${{ github.ref_name != default-branch || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
     outputs:
       version: ${{ steps.nuke-build.outputs.version }}
     steps:
@@ -264,5 +264,5 @@ jobs:
         package_version: ${{ needs.build.outputs.version }}
         packages: '*:NuGet.CommandLine:4.4.1'
         release_notes_file: ${{ (github.event_name == 'release' && steps.fetch-release-notes.outputs.release-note-file) || ''}}
-        git_ref: ${{ (github.ref_type == 'tag' && $default-branch ) || (github.head_ref || github.ref) }}
+        git_ref: ${{ (github.ref_type == 'tag' && default-branch ) || (github.head_ref || github.ref) }}
         git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -400,7 +400,7 @@ step "create-release-in-slipway" {
                 $slipwayToken = $OctopusParameters["SlipwayToken"]
                 $baseUrl = $OctopusParameters["SlipwayUrl"]
                 $version = $OctopusParameters["Octopus.Release.Number"]
-                $releaseNotes = $OctopusParameters["Octopus.Release.Notes"]
+                $releaseNotes = $OctopusParameters["Octopus.Deployment.ChangesMarkdown"]
                 
                 $headers = @{ "Authorization" = "Bearer $slipwayToken" }
                 
@@ -416,7 +416,7 @@ step "create-release-in-slipway" {
                         "IsPrerelease" = $isPreRelease;
                         "IsPublic" = $true;
                         "ReleaseNotes" = $releaseNotes;
-                        "ReleaseNotesMethod" = "GitRevisionGraph";
+                        "ReleaseNotesMethod" = "Milestones";
                     }
                 
                     write-verbose "POSTing the following JSON to $baseUrl/api/releases/create"

--- a/.octopus/deployment_settings.ocl
+++ b/.octopus/deployment_settings.ocl
@@ -1,10 +1,16 @@
+deployment_changes_template = <<-EOT
+        #{each release in Octopus.Deployment.Changes}
+        #{release.ReleaseNotes}
+        #{/each}
+    EOT
+
 connectivity_policy {
 }
 
 versioning_strategy {
 
     donor_package {
-        package = "PackageToUpload"
+        package = "f150a8fb-b150-49eb-9cc2-73ba630da381"
         step = "upload-octopustools-to-s3-public-with-hashes"
     }
 }

--- a/.octopus/deployment_settings.ocl
+++ b/.octopus/deployment_settings.ocl
@@ -10,7 +10,7 @@ connectivity_policy {
 versioning_strategy {
 
     donor_package {
-        package = "f150a8fb-b150-49eb-9cc2-73ba630da381"
+        package = "PackageToUpload"
         step = "upload-octopustools-to-s3-public-with-hashes"
     }
 }

--- a/.octopus/schema_version.ocl
+++ b/.octopus/schema_version.ocl
@@ -1,1 +1,1 @@
-version = 4
+version = 5


### PR DESCRIPTION
This PR updates the pipeline to get the release notes that Release Please will have attached to the Release in GitHub and push them through to Octopus.